### PR TITLE
Fixes `hx-get="/list-downloads/"` producing a 404 error

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,6 +66,21 @@ def get_spotdl():
     )
 
 
+def get_downloaded_files() -> str:
+    download_path = "/downloads"
+    try:
+        files = os.listdir(download_path)
+        file_links = [
+            f'<li class="list-group-item"><a href="/downloads/{file}">{file}</a></li>'
+            for file in files
+        ]
+        files = "".join(file_links) if file_links else '<li class="list-group-item">No files found.</li>'
+    except Exception as e:
+        files = f'<li class="list-group-item text-danger">Error: {str(e)}</li>'
+    
+    return files
+
+
 @app.get(
     '/',
     response_class=HTMLResponse,
@@ -148,15 +163,11 @@ def download(
 
 @app.get("/list", response_class=HTMLResponse, tags=['Web UI'], summary='List downloaded files')
 def list_downloads_page(request: Request):
-    download_path = "/downloads"
-    try:
-        files = os.listdir(download_path)
-        file_links = [
-            f'<li class="list-group-item"><a href="/downloads/{file}">{file}</a></li>'
-            for file in files
-        ]
-        files = "".join(file_links) if file_links else '<li class="list-group-item">No files found.</li>'
-    except Exception as e:
-        files = f'<li class="list-group-item text-danger">Error: {str(e)}</li>'
-
+    files = get_downloaded_files()
     return templates.TemplateResponse('list.html', {'request': request, 'files': files})
+
+
+@app.get('/list-items', response_class=HTMLResponse, tags=['Web UI'], summary='Returns downloaded files to list')
+def list_items_of_downloads_page():
+    files = get_downloaded_files()
+    return files

--- a/main.py
+++ b/main.py
@@ -40,10 +40,10 @@ app = FastAPI(
 app.mount('/static', StaticFiles(directory='static'), name='static')
 app.mount('/assets', StaticFiles(directory='assets'), name='assets')
 
-if not os.path.exists("/downloads"):
-    os.makedirs("/downloads")
+if not os.path.exists('/downloads'):
+    os.makedirs('/downloads')
 
-app.mount("/downloads", StaticFiles(directory="/downloads"), name="downloads")
+app.mount('/downloads', StaticFiles(directory='/downloads'), name='downloads')
 templates = Jinja2Templates(directory='templates')
 
 DOWNLOADER_OPTIONS: DownloaderOptions = {
@@ -67,17 +67,21 @@ def get_spotdl():
 
 
 def get_downloaded_files() -> str:
-    download_path = "/downloads"
+    download_path = '/downloads'
     try:
         files = os.listdir(download_path)
         file_links = [
             f'<li class="list-group-item"><a href="/downloads/{file}">{file}</a></li>'
             for file in files
         ]
-        files = "".join(file_links) if file_links else '<li class="list-group-item">No files found.</li>'
+        files = (
+            ''.join(file_links)
+            if file_links
+            else '<li class="list-group-item">No files found.</li>'
+        )
     except Exception as e:
         files = f'<li class="list-group-item text-danger">Error: {str(e)}</li>'
-    
+
     return files
 
 
@@ -161,13 +165,25 @@ def download(
         return {'detail': error}
 
 
-@app.get("/list", response_class=HTMLResponse, tags=['Web UI'], summary='List downloaded files')
+@app.get(
+    '/list',
+    response_class=HTMLResponse,
+    tags=['Web UI'],
+    summary='List downloaded files',
+)
 def list_downloads_page(request: Request):
     files = get_downloaded_files()
-    return templates.TemplateResponse('list.html', {'request': request, 'files': files})
+    return templates.TemplateResponse(
+        'list.html', {'request': request, 'files': files}
+    )
 
 
-@app.get('/list-items', response_class=HTMLResponse, tags=['Web UI'], summary='Returns downloaded files to list')
+@app.get(
+    '/list-items',
+    response_class=HTMLResponse,
+    tags=['Web UI'],
+    summary='Returns downloaded files to list',
+)
 def list_items_of_downloads_page():
     files = get_downloaded_files()
     return files

--- a/templates/list.html
+++ b/templates/list.html
@@ -46,7 +46,7 @@
     <main class="px-3 mt-5">
         <h1>Your Downloaded Files</h1>
         <p class="lead">Click on a file to open it.</p>
-        <ul class="list-group text-dark" id="file-list" hx-get="/list-downloads/" hx-trigger="load" hx-target="#file-list" hx-swap="innerHTML">
+        <ul class="list-group text-dark" id="file-list" hx-get="/list-items" hx-trigger="load" hx-target="#file-list" hx-swap="innerHTML">
             {{ files | safe }}
         </ul>
         <a href="/" class="btn btn-lg btn-light fw-bold border-white mt-5 mb-5 view-downloaded-musics-button">Back to download page</a>


### PR DESCRIPTION
This is done by adding an endpoint to return just the HTML with the downloaded items. @dvelayosmd if we added `hx-get="/list/"` to `list.html`, all the header and footer HTML would also be returned.