### PR TITLE
Allowing downloads of playlists with over 100 songs

### DIFF
--- a/downtify/spotify.py
+++ b/downtify/spotify.py
@@ -12,6 +12,7 @@ import re
 from typing import Any, Optional
 
 import requests
+from loguru import logger
 
 SPOTIFY_URL_RE = re.compile(
     r'(?:https?://)?(?:open\.)?spotify\.com/'
@@ -241,20 +242,160 @@ def _artists_from_subtitle(subtitle: Any) -> list[dict[str, str]]:
     ]
 
 
+def _token_from_embed_payload(payload: dict[str, Any]) -> Optional[str]:
+    """Extract the Spotify access token baked into the NEXT_DATA server state."""
+    try:
+        return payload['props']['pageProps']['state']['settings']['session'][
+            'accessToken'
+        ]
+    except (KeyError, TypeError):
+        return None
+
+
+_PARTNER_API = 'https://api-partner.spotify.com/pathfinder/v1/query'
+# sha256 of the fetchPlaylist GraphQL document in the Spotify web player.
+# Update when the player bundle rolls and the API returns PersistedQueryNotFound.
+# Location in the bundle: new tz.l("fetchPlaylist","query","<hash>",null)
+_GRAPHQL_HASH = (
+    'a65e12194ed5fc443a1cdebed5fabe33ca5b07b987185d63c72483867ad13cb4'
+)
+
+
+def _track_dict_from_graphql_item(
+    item: dict[str, Any],
+) -> Optional[dict[str, Any]]:
+    iv2 = item.get('itemV2') or {}
+    if iv2.get('__typename') != 'TrackResponseWrapper':
+        return None
+    track = iv2.get('data') or {}
+    if not isinstance(track, dict):
+        return None
+    track_id = _id_from_uri(track.get('uri') or '')
+    if not track_id:
+        return None
+    artists = [
+        a['profile']['name']
+        for a in (track.get('artists') or {}).get('items', [])
+        if isinstance(a, dict)
+        and isinstance(a.get('profile'), dict)
+        and a['profile'].get('name')
+    ]
+    album = track.get('albumOfTrack') or {}
+    album_name = album.get('name', '') if isinstance(album, dict) else ''
+    cover_sources = (album.get('coverArt') or {}).get('sources') or []
+    cover_url = _largest_image(cover_sources)
+    duration_ms = (track.get('trackDuration') or {}).get(
+        'totalMilliseconds'
+    ) or 0
+    label = (track.get('contentRating') or {}).get('label') or ''
+    return {
+        'song_id': track_id,
+        'name': track.get('name') or '',
+        'artists': artists,
+        'album_name': album_name,
+        'cover_url': cover_url,
+        'duration': int(duration_ms / 1000) if duration_ms else 0,
+        'url': f'https://open.spotify.com/track/{track_id}',
+        'explicit': label.upper() == 'EXPLICIT',
+        'year': '',
+        'source': 'spotify',
+    }
+
+
+def _graphql_fetch_page(
+    playlist_id: str, token: str, offset: int, limit: int = 100
+) -> dict[str, Any]:
+    resp = requests.get(
+        _PARTNER_API,
+        params={
+            'operationName': 'fetchPlaylist',
+            'variables': json.dumps({
+                'uri': f'spotify:playlist:{playlist_id}',
+                'offset': offset,
+                'limit': limit,
+                'enableWatchFeedEntrypoint': False,
+                'includeEpisodeContentRatingsV2': False,
+            }),
+            'extensions': json.dumps({
+                'persistedQuery': {
+                    'version': 1,
+                    'sha256Hash': _GRAPHQL_HASH,
+                }
+            }),
+        },
+        headers={
+            'Authorization': f'Bearer {token}',
+            'User-Agent': _USER_AGENT,
+            'app-platform': 'WebPlayer',
+        },
+        timeout=15,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    if 'errors' in data:
+        raise ValueError(f'GraphQL errors: {data["errors"]}')
+    return data['data']['playlistV2']
+
+
+def _graphql_all_tracks(
+    playlist_id: str, token: str
+) -> tuple[Optional[str], list[dict[str, Any]]]:
+    """Return ``(playlist_name_or_None, all_tracks)`` via partner GraphQL."""
+    songs: list[dict[str, Any]] = []
+    playlist_name: Optional[str] = None
+    offset = 0
+    limit = 100
+    while True:
+        pv2 = _graphql_fetch_page(playlist_id, token, offset, limit)
+        if playlist_name is None:
+            playlist_name = pv2.get('name') or None
+        content = pv2.get('content') or {}
+        items = content.get('items') or []
+        for item in items:
+            td = _track_dict_from_graphql_item(item)
+            if td:
+                songs.append(td)
+        total = content.get('totalCount') or 0
+        offset += len(items)
+        if not items or offset >= total:
+            break
+    return playlist_name, songs
+
+
 def playlist_tracks_from_id(playlist_id: str) -> list[dict[str, Any]]:
     payload = _fetch_embed_json('playlist', playlist_id)
     entity = _entity_from(payload)
+    token = _token_from_embed_payload(payload)
+    if token:
+        try:
+            _, tracks = _graphql_all_tracks(playlist_id, token)
+            return tracks
+        except Exception:
+            logger.opt(exception=True).warning(
+                'GraphQL pagination failed for {}; using embed data (limited)',
+                playlist_id,
+            )
     return _parse_playlist_tracks(entity)
 
 
 def playlist_info_and_tracks(
     playlist_id: str,
 ) -> tuple[str, list[dict[str, Any]]]:
-    """Return ``(playlist_name, tracks)`` in a single embed page fetch."""
+    """Return ``(playlist_name, tracks)`` fetching all tracks via partner GraphQL."""
     payload = _fetch_embed_json('playlist', playlist_id)
     entity = _entity_from(payload)
-    name = entity.get('name') or entity.get('title') or playlist_id
-    return name, _parse_playlist_tracks(entity)
+    embed_name = entity.get('name') or entity.get('title') or playlist_id
+    token = _token_from_embed_payload(payload)
+    if token:
+        try:
+            graphql_name, tracks = _graphql_all_tracks(playlist_id, token)
+            return graphql_name or embed_name, tracks
+        except Exception:
+            logger.opt(exception=True).warning(
+                'GraphQL pagination failed for {}; using embed data (limited)',
+                playlist_id,
+            )
+    return embed_name, _parse_playlist_tracks(entity)
 
 
 def _id_from_uri(uri: str) -> str:


### PR DESCRIPTION
This PR fixes the issue that prevented downloading more than 100 songs in playlists containing more than 100 songs.

fix #128