### PR TITLE
Check the album and song names

### DIFF
--- a/downtify/providers.py
+++ b/downtify/providers.py
@@ -166,6 +166,7 @@ def find_match(
     artists = song.get('artists') or []
     artists_q = ' '.join(artists)
     title = song.get('name', '')
+    album = song.get('album_name', '')
     query = f'{artists_q} {title}'.strip()
     if not query:
         return None, None
@@ -204,7 +205,7 @@ def find_match(
             ],
         )
         _log_ytm_response(f'find_match videos q={query[:80]!r}', results)
-    best = _pick_best(results, duration, title, artists)
+    best = _pick_best(results, duration, title, artists, album)
     if best is not None:
         logger.info(
             'YouTube Music find_match picked videoId={} title={!r} year={!r}',
@@ -215,7 +216,13 @@ def find_match(
         _log_ytm_response('find_match chosen row', best)
         return best.get('videoId'), best
     for result in results:
-        if result.get('videoId'):
+        # Same hard title requirement as `_pick_best`: never fall back to
+        # "the first result" if its title doesn't actually resemble the
+        # source track, or a duration/artist-only near-miss ends up
+        # downloaded under the wrong title.
+        if result.get('videoId') and (
+            not title or _titles_match(title, result.get('title'))
+        ):
             logger.info(
                 'YouTube Music find_match fallback first videoId={} title={!r}',
                 result.get('videoId'),
@@ -223,9 +230,17 @@ def find_match(
             )
             _log_ytm_response('find_match fallback row', result)
             return result['videoId'], result
+    # Text search sometimes never returns the correct video at all (see
+    # `_find_match_via_album`'s docstring) — try resolving it directly
+    # off the album's tracklist before giving up.
+    album_video_id, album_match = _find_match_via_album(song)
+    if album_video_id:
+        return album_video_id, album_match
     logger.info(
-        'YouTube Music find_match: no result for query={!r}',
+        'YouTube Music find_match: no title-matching result for '
+        'query={!r} target_title={!r}',
         query[:160],
+        title,
     )
     return None, None
 
@@ -273,6 +288,66 @@ def _norm_compact_title(value: Any) -> str:
     """Lowercase collapsed title for forgiving comparisons."""
 
     return re.sub(r'\s+', ' ', str(value or '').casefold()).strip()
+
+
+# Qualifiers that mark a genuinely different recording — a different
+# performance or edit, not just a different pressing of the same audio.
+# When one name is a prefix of the other (e.g. "Local Valley" vs "Local
+# Valley (Deluxe)"), the extra text is tolerated *unless* it contains one
+# of these — a plain "Tjomme" must never match "Tjomme (DJ Koze Remix)".
+# Extend this list as new special cases turn up.
+_VERSION_QUALIFIER_WORDS = (
+    'live',
+    'remix',
+    'cover',
+    'karaoke',
+    'acoustic',
+    'unplugged',
+    'demo',
+    'instrumental',
+    'tribute',
+)
+_VERSION_QUALIFIER_RE = re.compile(
+    r'\b(' + '|'.join(_VERSION_QUALIFIER_WORDS) + r')\b'
+)
+
+
+def _names_match(target: Any, candidate: Any) -> bool:
+    """True when two free-text names (title or album) refer to the same release.
+
+    An exact normalized match always counts. Otherwise one name may be a
+    prefix of the other, tolerating cosmetic edition tags a reissue adds
+    without changing the underlying content (``"(Deluxe)"``,
+    ``"(Remastered 2023)"``, ``"(Anniversary Edition)"``). The extra
+    text is rejected, however, if it names a genuinely different
+    recording — see :data:`_VERSION_QUALIFIER_WORDS`. A common prefix
+    shorter than 4 characters is never accepted, so short unrelated
+    names don't collide (``"U"`` must not match ``"Unplugged"``).
+    """
+
+    t = _norm_compact_title(target)
+    c = _norm_compact_title(candidate)
+    if not t or not c:
+        return False
+    if t == c:
+        return True
+    shorter, longer = sorted((t, c), key=len)
+    if len(shorter) < 4 or not longer.startswith(shorter):
+        return False
+    tail = longer[len(shorter) :]
+    return not _VERSION_QUALIFIER_RE.search(tail)
+
+
+def _albums_match(target: Any, candidate: Any) -> bool:
+    """True when two album names refer to the same release. See :func:`_names_match`."""
+
+    return _names_match(target, candidate)
+
+
+def _titles_match(target: Any, candidate: Any) -> bool:
+    """True when two song titles refer to the same recording. See :func:`_names_match`."""
+
+    return _names_match(target, candidate)
 
 
 def _album_title_hints(
@@ -484,6 +559,56 @@ def _cached_album_tracks_and_count(
     return tup
 
 
+def _find_match_via_album(
+    song: dict[str, Any],
+) -> tuple[Optional[str], Optional[dict[str, Any]]]:
+    """Resolve a track by scanning its album's tracklist directly.
+
+    YouTube Music's text search occasionally omits the correct video
+    from an "artist + title" query's own results entirely — e.g.
+    searching "José González Remain" never surfaces "Remain" itself,
+    while surfacing an unrelated track by the same artist (confirmed by
+    inspecting the raw search payload). When the source album is known,
+    resolving it via the ``albums`` filter and scanning its full
+    :func:`_cached_album_tracks_and_count` listing sidesteps that
+    search-relevance quirk entirely, since the tracklist is keyed by
+    album rather than by a fuzzy text query.
+    """
+
+    title = song.get('name', '')
+    album_name = str(song.get('album_name') or '').strip()
+    if not title or not album_name:
+        return None, None
+
+    browse_id = _album_browse_id_from_search({}, song)
+    if not browse_id:
+        return None, None
+
+    tracks, _total = _cached_album_tracks_and_count(browse_id)
+    for track in tracks:
+        if not isinstance(track, dict):
+            continue
+        video_id = _row_video_id(track)
+        if not video_id:
+            continue
+        if _titles_match(title, track.get('title')):
+            logger.info(
+                'YouTube Music find_match album-tracklist fallback hit '
+                'browseId={!r} videoId={} title={!r}',
+                browse_id,
+                video_id,
+                track.get('title'),
+            )
+            return video_id, track
+    logger.info(
+        'YouTube Music find_match album-tracklist fallback: no title '
+        'match in browseId={!r} for title={!r}',
+        browse_id,
+        title,
+    )
+    return None, None
+
+
 def youtube_music_track_index_for_match(
     match: Optional[dict[str, Any]],
     song: Optional[dict[str, Any]] = None,
@@ -644,11 +769,13 @@ def _pick_best(
     target_duration: int,
     target_title: str = '',
     target_artists: Optional[list[str]] = None,
+    target_album: str = '',
 ) -> Optional[dict[str, Any]]:
     target_title_l = (target_title or '').lower()
     target_artist_set = {
         (a or '').lower() for a in (target_artists or []) if a
     }
+    target_album_norm = _norm_compact_title(target_album)
 
     best: Optional[dict[str, Any]] = None
     best_score: float = float('inf')
@@ -663,6 +790,17 @@ def _pick_best(
         if any(
             kw in candidate_title and kw not in target_title_l
             for kw in _NEGATIVE_KEYWORDS
+        ):
+            continue
+
+        # Hard requirement: the title must actually resemble the source
+        # title. Duration/artist/album scoring alone can otherwise pick a
+        # completely unrelated song (e.g. a "- Remastered 2023" suffix
+        # throws off the search and every hit is a different track by the
+        # same artist) — better to reject the track than embed the wrong
+        # audio under the right metadata.
+        if target_title and not _titles_match(
+            target_title, result.get('title')
         ):
             continue
 
@@ -682,6 +820,23 @@ def _pick_best(
         }
         if target_artist_set and not (target_artist_set & candidate_artists):
             score += 30  # heavy penalty for wrong artist
+
+        # Album is the decisive signal when the source album is known: it
+        # separates the studio version from live / compilation / re-recorded
+        # takes of the same song that share title, artist and near-identical
+        # length (durations differ by a second or two, so duration alone is
+        # not enough). Only applied when the candidate carries album info so
+        # album-less `videos` results are not unfairly penalised.
+        if target_album_norm:
+            candidate_album = ''
+            alb = result.get('album')
+            if isinstance(alb, dict):
+                candidate_album = alb.get('name') or ''
+            if candidate_album:
+                if _albums_match(target_album, candidate_album):
+                    score -= 25
+                else:
+                    score += 15
 
         # Reward exact title matches over loosely-related ones.
         if candidate_title and target_title_l:

--- a/downtify/providers.py
+++ b/downtify/providers.py
@@ -216,12 +216,14 @@ def find_match(
         _log_ytm_response('find_match chosen row', best)
         return best.get('videoId'), best
     for result in results:
-        # Same hard title requirement as `_pick_best`: never fall back to
-        # "the first result" if its title doesn't actually resemble the
-        # source track, or a duration/artist-only near-miss ends up
-        # downloaded under the wrong title.
-        if result.get('videoId') and (
-            not title or _titles_match(title, result.get('title'))
+        # Same hard title/artist requirements as `_pick_best`: never fall
+        # back to "the first result" if its title doesn't actually
+        # resemble the source track, or if it shares the title but not
+        # the artist (title collisions across unrelated artists happen).
+        if (
+            result.get('videoId')
+            and (not title or _titles_match(title, result.get('title')))
+            and _artists_overlap(artists, result)
         ):
             logger.info(
                 'YouTube Music find_match fallback first videoId={} title={!r}',
@@ -747,6 +749,31 @@ def enrich_from_match(
     return enriched
 
 
+def _artists_overlap(
+    target_artists: Optional[list[str]], result: dict[str, Any]
+) -> bool:
+    """True when the candidate shares at least one artist with the target.
+
+    Vacuously true when the target's artist list is unknown, so callers
+    without artist context (e.g. an album-tracklist scan) aren't
+    unfairly blocked. Otherwise a hard requirement: a song that merely
+    shares its exact title with the target (title collisions across
+    unrelated artists are common for short/generic names — "Broken
+    Arrows" turns up from at least three different acts) must never be
+    picked just for being the "least wrong" duration match.
+    """
+
+    target_set = {(a or '').lower() for a in (target_artists or []) if a}
+    if not target_set:
+        return True
+    candidate_set = {
+        (a.get('name') or '').lower()
+        for a in (result.get('artists') or [])
+        if isinstance(a, dict)
+    }
+    return bool(target_set & candidate_set)
+
+
 _NEGATIVE_KEYWORDS = (
     'karaoke',
     'instrumental',
@@ -772,9 +799,6 @@ def _pick_best(
     target_album: str = '',
 ) -> Optional[dict[str, Any]]:
     target_title_l = (target_title or '').lower()
-    target_artist_set = {
-        (a or '').lower() for a in (target_artists or []) if a
-    }
     target_album_norm = _norm_compact_title(target_album)
 
     best: Optional[dict[str, Any]] = None
@@ -804,6 +828,12 @@ def _pick_best(
         ):
             continue
 
+        # Hard requirement: at least one artist must overlap. See
+        # `_artists_overlap`'s docstring — a title collision with an
+        # unrelated artist must never win on duration alone.
+        if not _artists_overlap(target_artists, result):
+            continue
+
         candidate_duration = result.get('duration_seconds') or _parse_duration(
             result.get('duration')
         )
@@ -811,15 +841,6 @@ def _pick_best(
             score = abs(candidate_duration - target_duration)
         else:
             score = 5
-
-        # Reward results whose artist list overlaps the source artists.
-        candidate_artists = {
-            (a.get('name') or '').lower()
-            for a in (result.get('artists') or [])
-            if isinstance(a, dict)
-        }
-        if target_artist_set and not (target_artist_set & candidate_artists):
-            score += 30  # heavy penalty for wrong artist
 
         # Album is the decisive signal when the source album is known: it
         # separates the studio version from live / compilation / re-recorded

--- a/downtify/providers.py
+++ b/downtify/providers.py
@@ -171,6 +171,49 @@ def find_match(
     if not query:
         return None, None
     duration = song.get('duration') or 0
+
+    # Try an unfiltered (default) search first. Unlike the category-
+    # filtered searches below, this is the only request that includes
+    # YouTube Music's own "Top result" card — its single best guess for
+    # the query — and it is empirically far more reliable than the
+    # `songs` shelf for tracks the filtered search omits entirely (e.g.
+    # "Remain" and "Broken Arrows (Remastered 2023)" are both absent
+    # from `filter='songs'` results for their own artist+title query,
+    # yet resolve instantly as the unfiltered Top result).
+    try:
+        top_results = _ytm().search(query, limit=5)
+    except Exception:
+        logger.exception('YouTube Music top-result search failed')
+        top_results = []
+    _log_ytm_summary_search(
+        phase='match_top_result',
+        query=query,
+        filt='default',
+        results_len=len(top_results),
+        first_titles=[
+            str(r.get('title') or '')[:60]
+            for r in top_results[:8]
+            if isinstance(r, dict)
+        ],
+    )
+    _log_ytm_response(f'find_match top-result q={query[:80]!r}', top_results)
+    usable_top_results = [
+        r
+        for r in top_results
+        if isinstance(r, dict) and r.get('resultType') in {'song', 'video'}
+    ]
+    top_best = _pick_best(usable_top_results, duration, title, artists, album)
+    if top_best is not None:
+        logger.info(
+            'YouTube Music find_match picked videoId={} title={!r} '
+            'year={!r} via=top_result',
+            top_best.get('videoId'),
+            top_best.get('title'),
+            top_best.get('year'),
+        )
+        _log_ytm_response('find_match chosen row (top result)', top_best)
+        return top_best.get('videoId'), top_best
+
     try:
         results = _ytm().search(query, filter='songs', limit=10)
     except Exception:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -7,6 +7,7 @@ import pytest
 from downtify import providers
 from downtify.providers import (
     _albums_match,
+    _artists_overlap,
     _find_match_via_album,
     _pick_best,
     _titles_match,
@@ -140,6 +141,36 @@ def test_enrich_preserves_preset_track_number(monkeypatch):
     )
     assert out['track_number'] == 7
     assert out['album_track_total'] == 11
+
+
+# ── _artists_overlap ───────────────────────────────────────────────────────────
+
+
+def test_artists_overlap_true_when_shared_artist():
+    result = {'artists': [{'name': 'José González'}]}
+    assert _artists_overlap(['José González'], result)
+
+
+def test_artists_overlap_false_for_unrelated_artist():
+    result = {'artists': [{'name': 'Kid Spirit'}, {'name': 'Maggie Szabo'}]}
+    assert not _artists_overlap(['José González'], result)
+
+
+def test_artists_overlap_true_when_any_credited_artist_matches():
+    # A multi-artist target (e.g. a feature) only needs one match.
+    result = {'artists': [{'name': 'Avicii'}]}
+    assert _artists_overlap(['Avicii', 'José González'], result)
+
+
+def test_artists_overlap_vacuously_true_without_target_artists():
+    result = {'artists': [{'name': 'Anyone'}]}
+    assert _artists_overlap([], result)
+    assert _artists_overlap(None, result)
+
+
+def test_artists_overlap_case_insensitive():
+    result = {'artists': [{'name': 'JOSÉ GONZÁLEZ'}]}
+    assert _artists_overlap(['josé gonzález'], result)
 
 
 # ── _albums_match ─────────────────────────────────────────────────────────────
@@ -341,6 +372,37 @@ def test_pick_best_rejects_all_candidates_with_wrong_title():
     assert best is None
 
 
+def test_pick_best_rejects_title_collision_across_unrelated_artists():
+    # Regression: "Broken Arrows" exists as three unrelated songs
+    # (José González's own bonus track, Avicii's "Stories" track, and a
+    # Kid Spirit & Maggie Szabo single). None of the wrong-artist hits
+    # should win just for having the closer duration to the target.
+    kid_spirit = _song_row(
+        'Broken Arrows', 'Kid Spirit', 'Broken Arrows', 165, 'wrong-close'
+    )
+    avicii = _song_row('Broken Arrows', 'Avicii', 'Stories', 233, 'wrong-far')
+    best = _pick_best(
+        [kid_spirit, avicii],
+        target_duration=118,
+        target_title='Broken Arrows',
+        target_artists=['José González'],
+    )
+    assert best is None
+
+
+def test_pick_best_accepts_featured_artist_not_in_candidate_list():
+    # A target with multiple credited artists (e.g. a feature) must
+    # still match a candidate that only lists one of them.
+    candidate = _song_row('Broken Arrows', 'Avicii', 'Stories', 233, 'right')
+    best = _pick_best(
+        [candidate],
+        target_duration=233,
+        target_title='Broken Arrows',
+        target_artists=['Avicii', 'José González'],
+    )
+    assert best['videoId'] == 'right'
+
+
 def test_pick_best_rejects_containment_match():
     # Regression: "Storm - Live" was matching "A Perfect Storm" (an
     # unrelated song) via substring containment on the base title.
@@ -479,6 +541,29 @@ def test_find_match_returns_none_when_no_title_matches(monkeypatch):
         'name': 'Slow Moves - Remastered 2023',
         'artists': ['José González'],
         'duration': 172,
+    })
+    assert video_id is None
+    assert match is None
+
+
+def test_find_match_rejects_title_collision_across_unrelated_artists(
+    monkeypatch,
+):
+    # Regression: "Broken Arrows" turns up as three unrelated songs; the
+    # fallback loop must reject the wrong-artist hits just like
+    # _pick_best does, rather than picking "the first result" by title
+    # alone. No album_name here, so the tracklist fallback is a no-op.
+    fake = _FakeYTM([
+        _song_row(
+            'Broken Arrows', 'Kid Spirit', 'Broken Arrows', 165, 'wrong'
+        ),
+        _song_row('Broken Arrows', 'Avicii', 'Stories', 233, 'also-wrong'),
+    ])
+    monkeypatch.setattr(providers, '_ytm', lambda: fake)
+    video_id, match = find_match({
+        'name': 'Broken Arrows',
+        'artists': ['José González'],
+        'duration': 118,
     })
     assert video_id is None
     assert match is None

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -6,9 +6,24 @@ import pytest
 
 from downtify import providers
 from downtify.providers import (
+    _albums_match,
+    _find_match_via_album,
+    _pick_best,
+    _titles_match,
     enrich_from_match,
+    find_match,
     youtube_music_track_index_for_match,
 )
+
+
+def _song_row(title, artist, album, duration, video_id):
+    return {
+        'videoId': video_id,
+        'title': title,
+        'artists': [{'name': artist}],
+        'album': {'name': album},
+        'duration_seconds': duration,
+    }
 
 
 @pytest.fixture(autouse=True)
@@ -125,3 +140,506 @@ def test_enrich_preserves_preset_track_number(monkeypatch):
     )
     assert out['track_number'] == 7
     assert out['album_track_total'] == 11
+
+
+# ── _albums_match ─────────────────────────────────────────────────────────────
+
+
+def test_albums_match_exact_casefold():
+    assert _albums_match('Acrobati', 'acrobati')
+
+
+def test_albums_match_tolerates_cosmetic_edition_suffix():
+    # Regression: "Local Valley" must still match "Local Valley (Deluxe)"
+    # — a reissue is the same release, not a different one.
+    assert _albums_match('Local Valley', 'Local Valley (Deluxe)')
+    assert _albums_match('Acrobati', 'Acrobati (Deluxe Edition)')
+    assert _albums_match('Unplugged', 'Unplugged [Remastered 2011]')
+
+
+def test_albums_match_rejects_version_qualified_suffix():
+    # "Live" (and friends) mark a genuinely different recording, so
+    # unlike a cosmetic edition tag it is never tolerated.
+    assert not _albums_match('Nevermind', 'Nevermind - Live')
+
+
+def test_albums_match_rejects_different_albums():
+    assert not _albums_match(
+        'Acrobati', 'Fabi Silvestri Gazzè Live al Circo Massimo'
+    )
+
+
+def test_albums_match_short_names_do_not_collide():
+    assert not _albums_match('RIP', 'Drip')
+
+
+def test_albums_match_empty_is_false():
+    assert not _albums_match('', 'Acrobati')
+    assert not _albums_match('Acrobati', '')
+
+
+# ── _pick_best album disambiguation ───────────────────────────────────────────
+
+
+def test_pick_best_prefers_correct_album_over_closer_duration():
+    # The "La mia casa" case: the wrong (live) take has the *closer*
+    # duration, so without the album signal it would win.
+    correct = _song_row(
+        'La mia casa', 'Daniele Silvestri', 'Acrobati', 240, 'right'
+    )
+    wrong = _song_row(
+        'La mia casa',
+        'Daniele Silvestri',
+        'Fabi Silvestri Gazzè Live al Circo Massimo',
+        238,
+        'wrong',
+    )
+    best = _pick_best(
+        [wrong, correct],
+        target_duration=238,
+        target_title='La mia casa',
+        target_artists=['Daniele Silvestri'],
+        target_album='Acrobati',
+    )
+    assert best['videoId'] == 'right'
+
+
+def test_pick_best_without_album_is_unchanged():
+    # No target album → duration remains the tiebreaker (legacy behaviour).
+    a = _song_row('La mia casa', 'Daniele Silvestri', 'Acrobati', 240, 'a')
+    b = _song_row('La mia casa', 'Daniele Silvestri', 'Live', 238, 'b')
+    best = _pick_best(
+        [a, b],
+        target_duration=238,
+        target_title='La mia casa',
+        target_artists=['Daniele Silvestri'],
+    )
+    assert best['videoId'] == 'b'
+
+
+def test_pick_best_prefers_exact_album_match():
+    correct = _song_row('Song', 'Artist', 'The Album', 200, 'right')
+    other = _song_row('Song', 'Artist', 'Some Compilation', 200, 'other')
+    best = _pick_best(
+        [other, correct],
+        target_duration=200,
+        target_title='Song',
+        target_artists=['Artist'],
+        target_album='The Album',
+    )
+    assert best['videoId'] == 'right'
+
+
+def test_pick_best_does_not_penalise_albumless_video_results():
+    # `videos`-filter fallback rows have no album; they must stay eligible
+    # when nothing else matches the album.
+    only = {
+        'videoId': 'vid',
+        'title': 'Song',
+        'artists': [{'name': 'Artist'}],
+        'duration_seconds': 200,
+    }
+    best = _pick_best(
+        [only],
+        target_duration=200,
+        target_title='Song',
+        target_artists=['Artist'],
+        target_album='Some Album',
+    )
+    assert best['videoId'] == 'vid'
+
+
+# ── _titles_match ─────────────────────────────────────────────────────────────
+
+
+def test_titles_match_exact_casefold():
+    assert _titles_match('Slow Moves', 'slow moves')
+
+
+def test_titles_match_tolerates_only_whitespace_differences():
+    assert _titles_match('Slow  Moves', 'Slow Moves')
+
+
+def test_titles_match_tolerates_cosmetic_suffix():
+    # A cosmetic edition tag (remaster, radio edit, …) does not make it
+    # a different recording, so the bare title still matches.
+    assert _titles_match(
+        'Slow Moves - Remastered 2023', 'Slow Moves - Remastered 2023'
+    )
+    assert _titles_match('Slow Moves - Remastered 2023', 'Slow Moves')
+    assert _titles_match('Song (Radio Edit)', 'Song')
+
+
+def test_titles_match_rejects_unrelated_titles():
+    assert not _titles_match('Slow Moves', 'Just A Rock')
+    assert not _titles_match('Slow Moves', 'How Low')
+
+
+def test_titles_match_short_names_do_not_collide():
+    assert not _titles_match('U', 'You & We')
+
+
+def test_titles_match_rejects_containment():
+    # Regression: "Storm - Live" must not match "A Perfect Storm" just
+    # because the base name ("storm") is a substring of the candidate.
+    assert not _titles_match('Storm - Live', 'A Perfect Storm')
+    assert not _titles_match('Storm', 'A Perfect Storm')
+
+
+def test_titles_match_live_target_rejects_studio_candidate():
+    # Regression: "Save Your Day - Live" was matching the plain studio
+    # "Save Your Day" hit, downloading the wrong (non-live) recording
+    # under live metadata.
+    assert not _titles_match('Save Your Day - Live', 'Save Your Day')
+
+
+def test_titles_match_rejects_differently_formatted_live_tag():
+    # Deliberately strict: even a genuine live take is rejected if
+    # YouTube Music doesn't spell the qualifier exactly like Spotify does.
+    assert not _titles_match('Save Your Day - Live', 'Save Your Day (Live)')
+    assert _titles_match('Save Your Day - Live', 'Save Your Day - Live')
+
+
+def test_titles_match_studio_target_rejects_live_candidate():
+    # The mirror case: a plain studio target must not accept a live take.
+    assert not _titles_match('Save Your Day', 'Save Your Day (Live)')
+
+
+def test_titles_match_rejects_remix_for_plain_target():
+    # Regression: "Tjomme" must not match "Tjomme (DJ Koze Remix)" — a
+    # remix is a different recording, not just a different pressing.
+    assert not _titles_match('Tjomme', 'Tjomme (DJ Koze Remix)')
+
+
+def test_titles_match_qualifier_words_are_word_bounded():
+    # The word "Olive" contains the letters "live" but is not the
+    # qualifier "live" — the check on the extra suffix text must use
+    # word boundaries, not a bare substring search.
+    assert _titles_match('Storm', 'Storm (Olive Edition)')
+
+
+# ── _pick_best rejects title-mismatched candidates ────────────────────────────
+
+
+def test_pick_best_rejects_all_candidates_with_wrong_title():
+    # Reproduces the "Slow Moves" bug: YouTube Music returns only unrelated
+    # songs by the same artist with plausible durations/artist overlap, and
+    # none of them should be accepted.
+    candidates = [
+        _song_row(
+            'This Is How We Walk on the Moon', 'José González', '', 307, 'a'
+        ),
+        _song_row('How Low', 'José González', '', 161, 'b'),
+        _song_row('Just A Rock', 'José González', '', 172, 'c'),
+    ]
+    best = _pick_best(
+        candidates,
+        target_duration=172,
+        target_title='Slow Moves - Remastered 2023',
+        target_artists=['José González'],
+    )
+    assert best is None
+
+
+def test_pick_best_rejects_containment_match():
+    # Regression: "Storm - Live" was matching "A Perfect Storm" (an
+    # unrelated song) via substring containment on the base title.
+    candidates = [
+        _song_row('A Perfect Storm', 'José González', '', 185, 'wrong'),
+    ]
+    best = _pick_best(
+        candidates,
+        target_duration=185,
+        target_title='Storm - Live',
+        target_artists=['José González'],
+    )
+    assert best is None
+
+
+def test_pick_best_rejects_remix_when_no_plain_take_available():
+    # Regression: "Tjomme" (from the "Local Valley (Deluxe)" bonus disc)
+    # only turns up as "Tjomme (DJ Koze Remix)" on YouTube Music — a
+    # different recording, so this must error rather than download it.
+    candidates = [
+        _song_row(
+            'Tjomme (DJ Koze Remix)',
+            'José González',
+            'Local Valley (Deluxe)',
+            363,
+            'remix',
+        ),
+    ]
+    best = _pick_best(
+        candidates,
+        target_duration=154,
+        target_title='Tjomme',
+        target_artists=['José González'],
+        target_album='Local Valley',
+    )
+    assert best is None
+
+
+def test_pick_best_accepts_deluxe_album_for_plain_target():
+    # The album counterpart of the same regression: the correct plain
+    # take lives on the "(Deluxe)" reissue and must still be accepted.
+    candidates = [
+        _song_row(
+            'Tjomme', 'José González', 'Local Valley (Deluxe)', 154, 'right'
+        ),
+    ]
+    best = _pick_best(
+        candidates,
+        target_duration=154,
+        target_title='Tjomme',
+        target_artists=['José González'],
+        target_album='Local Valley',
+    )
+    assert best['videoId'] == 'right'
+
+
+def test_pick_best_prefers_exact_title_match_over_studio_take():
+    # Regression: "Save Your Day - Live" / "Crosses - Live" were matching
+    # the plain studio hit from the Veneer album instead of the actual
+    # live recording, even when an exactly-titled live take was present
+    # among the search results.
+    studio = _song_row('Crosses', 'José González', 'Veneer', 441, 'studio')
+    live = _song_row(
+        'Crosses - Live', 'José González', 'Live Sessions', 430, 'live'
+    )
+    best = _pick_best(
+        [studio, live],
+        target_duration=430,
+        target_title='Crosses - Live',
+        target_artists=['José González'],
+    )
+    assert best['videoId'] == 'live'
+
+
+def test_pick_best_errors_out_when_only_studio_take_available():
+    # No live-tagged candidate exists at all → must not silently fall
+    # back to the studio recording.
+    studio_only = [
+        _song_row('Save Your Day', 'José González', 'Veneer', 200, 'studio'),
+    ]
+    best = _pick_best(
+        studio_only,
+        target_duration=200,
+        target_title='Save Your Day - Live',
+        target_artists=['José González'],
+    )
+    assert best is None
+
+
+def test_pick_best_accepts_title_matching_candidate_among_noise():
+    candidates = [
+        _song_row('Just A Rock', 'José González', '', 172, 'wrong'),
+        _song_row(
+            'Slow Moves - Remastered 2023',
+            'José González',
+            'Veneer',
+            172,
+            'right',
+        ),
+    ]
+    best = _pick_best(
+        candidates,
+        target_duration=172,
+        target_title='Slow Moves - Remastered 2023',
+        target_artists=['José González'],
+        target_album='Veneer',
+    )
+    assert best['videoId'] == 'right'
+
+
+# ── find_match errors the song instead of downloading a mismatch ─────────────
+
+
+class _FakeYTM:
+    def __init__(self, results):
+        self._results = results
+
+    def search(self, query, filter=None, limit=10):
+        return self._results
+
+
+def test_find_match_returns_none_when_no_title_matches(monkeypatch):
+    # Only the `songs` filter is exercised; `videos` fallback is unused here
+    # since `songs` already returned non-empty results. No `album_name` is
+    # given, so the album-tracklist fallback short-circuits immediately
+    # rather than attempting a real network call.
+    fake = _FakeYTM([
+        _song_row(
+            'This Is How We Walk on the Moon', 'José González', '', 307, 'a'
+        ),
+        _song_row('How Low', 'José González', '', 161, 'b'),
+        _song_row('Just A Rock', 'José González', '', 172, 'c'),
+    ])
+    monkeypatch.setattr(providers, '_ytm', lambda: fake)
+    video_id, match = find_match({
+        'name': 'Slow Moves - Remastered 2023',
+        'artists': ['José González'],
+        'duration': 172,
+    })
+    assert video_id is None
+    assert match is None
+
+
+def test_find_match_falls_back_to_album_tracklist_when_search_misses(
+    monkeypatch,
+):
+    # End-to-end reproduction of the "Remain" bug: YouTube Music's own
+    # "artist + title" search for "José González Remain" never returns
+    # "Remain" among its results (confirmed against production logs) —
+    # find_match must fall back to the album tracklist and still resolve
+    # the correct video.
+    fake = _FakeYTM([
+        _song_row(
+            'Deadweight on Velveteen', 'José González', 'Veneer', 207, 'x'
+        ),
+        _song_row('Crosses', 'José González', 'Veneer', 162, 'y'),
+    ])
+    monkeypatch.setattr(providers, '_ytm', lambda: fake)
+    monkeypatch.setattr(
+        providers,
+        '_find_match_via_album',
+        lambda song: (
+            'TzIpcPo8UIo',
+            {'videoId': 'TzIpcPo8UIo', 'title': 'Remain'},
+        ),
+    )
+    video_id, match = find_match({
+        'name': 'Remain',
+        'album_name': 'Veneer',
+        'artists': ['José González'],
+        'duration': 226,
+    })
+    assert video_id == 'TzIpcPo8UIo'
+    assert match['title'] == 'Remain'
+
+
+def test_find_match_returns_none_when_album_fallback_also_fails(monkeypatch):
+    fake = _FakeYTM([
+        _song_row('Just A Rock', 'José González', 'Veneer', 172, 'c'),
+    ])
+    monkeypatch.setattr(providers, '_ytm', lambda: fake)
+    monkeypatch.setattr(
+        providers, '_find_match_via_album', lambda song: (None, None)
+    )
+    video_id, match = find_match({
+        'name': 'Remain',
+        'album_name': 'Veneer',
+        'artists': ['José González'],
+        'duration': 226,
+    })
+    assert video_id is None
+    assert match is None
+
+
+# ── _find_match_via_album ─────────────────────────────────────────────────────
+
+
+def test_find_match_via_album_finds_track_missing_from_text_search(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        providers,
+        '_album_browse_id_from_search',
+        lambda *_a, **_kw: 'MPREb_r66dI91cUVz',
+    )
+    monkeypatch.setattr(
+        providers,
+        '_cached_album_tracks_and_count',
+        lambda _browse_id: (
+            [
+                {'videoId': 'eAX90iTkiPk', 'title': 'Slow Moves'},
+                {'videoId': 'TzIpcPo8UIo', 'title': 'Remain'},
+            ],
+            10,
+        ),
+    )
+    video_id, match = _find_match_via_album({
+        'name': 'Remain',
+        'album_name': 'Veneer',
+        'artists': ['José González'],
+    })
+    assert video_id == 'TzIpcPo8UIo'
+    assert match['title'] == 'Remain'
+
+
+def test_find_match_via_album_returns_none_without_album_name(monkeypatch):
+    def _boom(*_a, **_kw):
+        raise AssertionError('should not be called without an album name')
+
+    monkeypatch.setattr(providers, '_album_browse_id_from_search', _boom)
+    video_id, match = _find_match_via_album({
+        'name': 'Remain',
+        'album_name': '',
+        'artists': ['José González'],
+    })
+    assert video_id is None
+    assert match is None
+
+
+def test_find_match_via_album_returns_none_when_album_not_resolved(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        providers, '_album_browse_id_from_search', lambda *_a, **_kw: ''
+    )
+    video_id, match = _find_match_via_album({
+        'name': 'Remain',
+        'album_name': 'Veneer',
+        'artists': ['José González'],
+    })
+    assert video_id is None
+    assert match is None
+
+
+def test_find_match_via_album_returns_none_when_title_absent_from_tracklist(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        providers,
+        '_album_browse_id_from_search',
+        lambda *_a, **_kw: 'MPREb_r66dI91cUVz',
+    )
+    monkeypatch.setattr(
+        providers,
+        '_cached_album_tracks_and_count',
+        lambda _browse_id: (
+            [{'videoId': 'eAX90iTkiPk', 'title': 'Slow Moves'}],
+            10,
+        ),
+    )
+    video_id, match = _find_match_via_album({
+        'name': 'Remain',
+        'album_name': 'Veneer',
+        'artists': ['José González'],
+    })
+    assert video_id is None
+    assert match is None
+
+
+def test_find_match_via_album_still_rejects_version_mismatch(monkeypatch):
+    # Same qualifier-aware strictness as the direct search path: a remix
+    # sitting in the tracklist must not stand in for the plain studio cut.
+    monkeypatch.setattr(
+        providers,
+        '_album_browse_id_from_search',
+        lambda *_a, **_kw: 'MPREb_pWSf6KQ4ms0',
+    )
+    monkeypatch.setattr(
+        providers,
+        '_cached_album_tracks_and_count',
+        lambda _browse_id: (
+            [{'videoId': 'JOgU2SajisQ', 'title': 'Tjomme (DJ Koze Remix)'}],
+            11,
+        ),
+    )
+    video_id, match = _find_match_via_album({
+        'name': 'Tjomme',
+        'album_name': 'Local Valley',
+        'artists': ['José González'],
+    })
+    assert video_id is None
+    assert match is None

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -524,6 +524,96 @@ class _FakeYTM:
         return self._results
 
 
+class _FakeYTMByFilter:
+    """Routes ``search()`` results by the ``filter`` kwarg, so tests can
+    tell find_match's staged search attempts (unfiltered top-result,
+    `songs`, `videos`) apart."""
+
+    def __init__(self, by_filter):
+        self._by_filter = by_filter
+
+    def search(self, query, filter=None, limit=10):
+        return self._by_filter.get(filter, [])
+
+
+def test_find_match_uses_unfiltered_top_result_when_present(monkeypatch):
+    # Regression: "Broken Arrows (Remastered 2023)" (like "Remain" and
+    # "Deadweight on Velveteen") is absent from the `songs`-filtered
+    # search entirely, but resolves instantly as the unfiltered "Top
+    # result" — find_match must try that first.
+    top_result = {
+        'category': 'Top result',
+        'resultType': 'song',
+        'videoId': 'right',
+        'title': 'Broken Arrows',
+        'artists': [{'name': 'José González'}],
+        'duration_seconds': 118,
+    }
+    songs_filtered = [
+        _song_row(
+            'Broken Arrows', 'Kid Spirit', 'Broken Arrows', 165, 'wrong'
+        ),
+        _song_row('Broken Arrows', 'Avicii', 'Stories', 233, 'also-wrong'),
+    ]
+    fake = _FakeYTMByFilter({None: [top_result], 'songs': songs_filtered})
+    monkeypatch.setattr(providers, '_ytm', lambda: fake)
+    video_id, match = find_match({
+        'name': 'Broken Arrows',
+        'artists': ['José González'],
+        'duration': 118,
+    })
+    assert video_id == 'right'
+
+
+def test_find_match_ignores_non_song_or_video_top_result(monkeypatch):
+    # An album/artist/playlist Top result must not short-circuit the
+    # match; find_match should fall through to the filtered search.
+    top_result = {
+        'category': 'Top result',
+        'resultType': 'artist',
+        'browseId': 'x',
+    }
+    songs_filtered = [
+        _song_row(
+            'Broken Arrows', 'José González', 'Broken Arrows', 118, 'right'
+        ),
+    ]
+    fake = _FakeYTMByFilter({None: [top_result], 'songs': songs_filtered})
+    monkeypatch.setattr(providers, '_ytm', lambda: fake)
+    video_id, match = find_match({
+        'name': 'Broken Arrows',
+        'artists': ['José González'],
+        'duration': 118,
+    })
+    assert video_id == 'right'
+
+
+def test_find_match_falls_through_when_top_result_fails_gates(monkeypatch):
+    # Same strictness as everywhere else: a Top result that doesn't pass
+    # the title/artist gates is not accepted just for being "Top result".
+    top_result = {
+        'category': 'Top result',
+        'resultType': 'song',
+        'videoId': 'wrong',
+        'title': 'Something Else Entirely',
+        'artists': [{'name': 'Unrelated Artist'}],
+        'duration_seconds': 118,
+    }
+    songs_filtered = [
+        _song_row(
+            'Broken Arrows', 'José González', 'Broken Arrows', 118, 'right'
+        ),
+    ]
+    fake = _FakeYTMByFilter({None: [top_result], 'songs': songs_filtered})
+    monkeypatch.setattr(providers, '_ytm', lambda: fake)
+    video_id, match = find_match({
+        'name': 'Broken Arrows',
+        'artists': ['José González'],
+        'duration': 118,
+    })
+    assert video_id == 'right'
+
+
 def test_find_match_returns_none_when_no_title_matches(monkeypatch):
     # Only the `songs` filter is exercised; `videos` fallback is unused here
     # since `songs` already returned non-empty results. No `album_name` is


### PR DESCRIPTION
## Fix wrong-song matches from YouTube Music while downloading Spotify full albums

### Root cause
`find_match` searched YouTube Music with `filter='songs'`, which sends a different backend request than a plain search and never includes YT Music's own "Top result" card — the single best guess it shows first in the browser. For several tracks, the correct video was **completely absent** from the `songs`-filtered shelf, so scoring picked the least-wrong decoy instead — sometimes a different song from a different artist that merely shared the exact title.

### Fixes
- **Unfiltered "Top result" search added as the first attempt.** Confirmed live that this alone resolves every previously-broken track correctly. `resultType` is only used to filter candidates to `song`/`video` — it's not otherwise preferred (a Top result is often typed `video` even for the correct official track), so it doesn't bias scoring beyond eligibility.
- **Title matching made strict but suffix-tolerant.** Exact match required, but a name may be a prefix of the candidate to tolerate cosmetic edition tags (`"(Deluxe)"`, `"(Remastered 2023)"`). An explicit blocklist (`live`, `remix`, `cover`, `acoustic`, `unplugged`, `demo`, `instrumental`, `tribute`) rejects the extra text when it marks a genuinely different recording, so `"Tjomme"` won't match `"Tjomme (DJ Koze Remix)"`, but `"Local Valley"` still matches `"Local Valley (Deluxe)"`.
- **Album matching uses the same rule** (shared implementation with title matching).
- **Artist overlap is now a hard requirement**, not a soft score penalty — previously a wrong-artist candidate could still win if it had the closest duration among bad options (e.g. "Broken Arrows" existing as three unrelated songs by different artists).
- **Album-tracklist fallback**: when text search still misses, resolve the album via YT Music's `albums` filter and scan its full tracklist for a title match, sidestepping search-relevance quirks entirely.
- When no candidate passes these checks, the track is now correctly **skipped/errored** instead of downloading mismatched audio under the wrong metadata.
