### PR TITLE
fix: save MP3 tags as ID3v2.4 instead of v2.3

### DIFF
--- a/downtify/downloader.py
+++ b/downtify/downloader.py
@@ -720,7 +720,15 @@ def _tag_mp3(
                 data=cover_bytes,
             )
         )
-    audio.save(v2_version=3)
+    # ID3v2.3 has no UTF-8 text encoding (only Latin-1/UTF-16), so saving
+    # v2.3 frames created with encoding=3 forces mutagen to transcode them
+    # to UTF-16 on write. That conversion corrupts the tail of the frame
+    # (observed: the last 1-2 characters replaced with garbage code
+    # points), which then desyncs the ID3 reader for every frame that
+    # follows TIT2 — silently dropping artist/album/genre/date/track
+    # number/cover on read. v2.4 supports UTF-8 natively, so no forced
+    # transcode happens.
+    audio.save(v2_version=4)
 
 
 def _tag_mp4(
@@ -936,7 +944,9 @@ def embed_lyrics(path: Path, lyrics: 'lyrics_mod.Lyrics') -> None:
             audio.add_tags()
         audio.tags.delall('USLT')
         audio.tags.add(USLT(encoding=3, lang='eng', desc='', text=text))
-        audio.save(v2_version=3)
+        # See the matching comment in _tag_mp3: v2.3 forces a UTF-8 ->
+        # UTF-16 transcode on save that corrupts long text frames.
+        audio.save(v2_version=4)
     elif suffix in {'m4a', 'mp4', 'aac'}:
         audio = MP4(str(path))
         audio['\xa9lyr'] = text

--- a/tests/test_downloader_extended.py
+++ b/tests/test_downloader_extended.py
@@ -3,14 +3,89 @@ organize_by_artist routing logic."""
 
 from __future__ import annotations
 
+import base64
 from pathlib import Path
 
+from mutagen.id3 import ID3
+
 from downtify import downloader as downloader_mod
-from downtify.downloader import Downloader, _release_type_for_tags
+from downtify.downloader import (
+    Downloader,
+    _release_type_for_tags,
+    _tag_mp3,
+    embed_lyrics,
+)
+from downtify.lyrics import Lyrics
 
 
 def _make(tmp_path: Path, **kwargs) -> Downloader:
     return Downloader(tmp_path, **kwargs)
+
+
+# A minimal-but-real single-frame MP3 (silence, ~0.1s), generated with
+# ffmpeg. mutagen's MP3 class needs an actual MPEG audio frame to
+# recognize the file and attach ID3 tags to it — an empty/garbage file
+# is rejected before the ID3 write path is even reached.
+_MINIMAL_MP3_B64 = (
+    'SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjYwLjE2LjEwMAAAAAAAAAAAAAAA/+MYxAAAAANIAAA'
+    'AAExBTUUzLjEwMFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV'
+    'VVVVVV/+MYxDsAAANIAAAAAFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV'
+    'VVVVVVVVVVVVVVVVVVVVVVVVVVV/+MYxHYAAANIAAAAAFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV'
+    'VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV/+MYxLEAAANIAAAAAFVVVVVVVVV'
+    'VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV'
+)
+
+
+def _minimal_mp3(path: Path) -> Path:
+    path.write_bytes(base64.b64decode(_MINIMAL_MP3_B64))
+    return path
+
+
+# ── ID3v2.4 tagging (regression: v2.3 + UTF-8 corruption) ──────────────────────
+
+
+def test_tag_mp3_round_trips_long_title_without_corruption(tmp_path):
+    """Guards the ID3v2.4 save: every frame written by _tag_mp3 must
+    round-trip byte-for-byte. See the v2_version comment in _tag_mp3
+    for why v2.4 (native UTF-8) is used instead of v2.3, which has no
+    UTF-8 text encoding and forces mutagen to transcode encoding=3
+    frames to UTF-16 on save."""
+    mp3_path = _minimal_mp3(tmp_path / 'song.mp3')
+    _tag_mp3(
+        mp3_path,
+        title="Baba O'Riley",
+        artists=['The Who'],
+        album_artist='The Who',
+        album="Who's Next",
+        year='1971',
+        genre='Rock',
+        cover_bytes=None,
+        track_number=1,
+        album_track_total=9,
+        release_type='album',
+    )
+
+    tags = ID3(mp3_path)
+    assert str(tags.getall('TIT2')[0]) == "Baba O'Riley"
+    assert str(tags.getall('TPE1')[0]) == 'The Who'
+    assert str(tags.getall('TPE2')[0]) == 'The Who'
+    assert str(tags.getall('TALB')[0]) == "Who's Next"
+    assert str(tags.getall('TDRC')[0]) == '1971'
+    assert str(tags.getall('TCON')[0]) == 'Rock'
+    assert str(tags.getall('TRCK')[0]) == '1/9'
+
+
+def test_embed_lyrics_mp3_round_trips_without_corruption(tmp_path):
+    """Same v2.4-vs-v2.3 concern as _tag_mp3, but for the USLT (lyrics)
+    save path."""
+    mp3_path = _minimal_mp3(tmp_path / 'song.mp3')
+    lyrics_text = '\n'.join(
+        f'Line {i} of a fairly long set of lyrics' for i in range(20)
+    )
+    embed_lyrics(mp3_path, Lyrics(plain=lyrics_text))
+
+    tags = ID3(mp3_path)
+    assert str(tags.getall('USLT::eng')[0]) == lyrics_text
 
 
 # ── _format_basename ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## What changed

`_tag_mp3()` and `embed_lyrics()` (mp3 branch) save with `audio.save(v2_version=3)`. ID3v2.3 has no UTF-8 text encoding (only Latin-1/UTF-16), so saving v2.3 frames that were created with `encoding=3` (UTF-8) forces mutagen to transcode them to UTF-16 on write. Both save calls now use `v2_version=4`, which supports UTF-8 natively.

## Why

On a self-hosted instance running mutagen 1.47.0, this was observed to corrupt the written `TIT2` (title) frame — the tail of the string replaced with the same garbage characters across many unrelated tracks (e.g. `Baba O'Riley` → `Baba O'Rileﯿä`). That corruption desynced the ID3 reader for every frame written *after* TIT2, silently losing artist, album, genre, date, track number and cover art on read. It affected essentially every track downloaded by that instance — re-tagging ~1700 already-downloaded files with `v2_version=4` (no code/audio changes, just re-running the fixed tagging function against the existing files) restored every frame correctly and consistently.

## Verification

- `_tag_mp3`/`embed_lyrics` are otherwise unchanged — this only touches which ID3 version gets written.
- Added `tests/test_downloader_extended.py::test_tag_mp3_round_trips_long_title_without_corruption` and `::test_embed_lyrics_mp3_round_trips_without_corruption`, both green.
- **Honesty note on test coverage**: I was not able to isolate a minimal synthetic reproduction of the exact corruption trigger, despite trying several realistic variations against mutagen 1.47.0 directly (a tiny single-frame file, a full-size 7MB 320kbps file, a file with a pre-existing ffmpeg-written tag, repeated re-saves simulating a retry, and even re-tagging one of the actually-affected files from the instance where this was observed) — none corrupted under `v2_version=3` in isolation. So the two tests above are round-trip/regression guards for the *current* v2.4 behavior, not a failing-before/passing-after demonstration of the original bug. I'm not 100% sure what the precise trigger condition was (it's possible it depends on something specific to that instance/environment, e.g. YouTube's SABR rollout was also causing malformed audio downloads around the same time — see the companion PR). Flagging this clearly per the "explain why manual verification was done instead" guidance in CONTRIBUTING.md, since I couldn't produce a clean failing test.
- `make lint` / `ruff format` / `ruff check`: clean.
- `pytest -x -s -v`: full suite green (342 passed).