### PR TITLE
fix: enable yt-dlp's remote EJS component for YouTube SABR fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,9 @@ RUN apk add --no-cache \
     ffmpeg \
     shadow \
     su-exec \
-    tini
+    tini \
+    deno \
+    yt-dlp-ejs-rt-deno
 
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin

--- a/downtify/downloader.py
+++ b/downtify/downloader.py
@@ -384,6 +384,15 @@ class Downloader:
             'extractor_args': {
                 'youtube': {'player_client': _yt_player_clients()}
             },
+            # `web`/`web_embedded` need a JS runtime to solve YouTube's
+            # signature/n-challenges (see the comment on
+            # _DEFAULT_YT_PLAYER_CLIENTS above) — that's the only real
+            # fallback once `ios`/`android` get SABR-gated. yt-dlp
+            # refuses to fetch its EJS challenge-solver script by
+            # default, so without this the JS runtime never actually
+            # gets used and those two clients silently yield no audio
+            # (see henriquesebastiao/downtify#247).
+            'remote_components': ['ejs:github'],
             # Light pacing so we don't trigger 429 rate limits when the
             # user fires off multiple downloads back-to-back.
             'sleep_interval_requests': 1,

--- a/tests/test_downloader_extended.py
+++ b/tests/test_downloader_extended.py
@@ -370,3 +370,49 @@ def test_release_type_for_tags_missing_key_returns_empty():
 
 def test_release_type_for_tags_none_value_returns_empty():
     assert not _release_type_for_tags({'release_type': None})
+
+
+# ── download() ydl_opts (remote EJS components for SABR fallback) ──────────────
+
+
+class _CapturedOpts(Exception):
+    """Raised by the fake YoutubeDL to stop download() before it would
+    otherwise touch the network, once we've captured ydl_opts."""
+
+
+class _FakeYoutubeDL:
+    captured: dict = {}
+
+    def __init__(self, opts):
+        _FakeYoutubeDL.captured = opts
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def download(self, urls):  # noqa: PLR6301 - mirrors yt_dlp.YoutubeDL's API
+        raise _CapturedOpts
+
+
+def test_download_ydl_opts_enables_remote_ejs_component(tmp_path, monkeypatch):
+    """Without `remote_components: ['ejs:github']`, yt-dlp refuses to
+    fetch the EJS challenge-solver script even when a JS runtime is
+    installed, so the `web`/`web_embedded` fallback clients silently
+    yield no audio once YouTube's SABR rollout gates `ios`/`android`
+    (henriquesebastiao/downtify#247)."""
+    monkeypatch.setattr(downloader_mod.yt_dlp, 'YoutubeDL', _FakeYoutubeDL)
+    d = _make(tmp_path)
+    song = {
+        'name': 'Song',
+        'artists': ['Artist'],
+        'youtube_id': 'abc123def45',
+        'album_name': 'Album',
+        'cover_url': 'https://example.com/cover.jpg',
+    }
+    try:
+        d.download(song)
+    except _CapturedOpts:
+        pass
+    assert _FakeYoutubeDL.captured.get('remote_components') == ['ejs:github']


### PR DESCRIPTION
Fixes #247

## What changed

- `downtify/downloader.py`: add `'remote_components': ['ejs:github']` to `ydl_opts`.
- `Dockerfile`: install `deno` (JS runtime — native Alpine/musl build, avoids the glibc-compatibility issues Deno's official prebuilt binaries have on Alpine) and `yt-dlp-ejs-rt-deno` (the Deno-based EJS challenge-solver script yt-dlp needs), both available in Alpine's community repo.

## Why

YouTube's SABR-only streaming experiment (yt-dlp/yt-dlp#12482) gates audio formats for the `ios`/`android` player clients — the two `_DEFAULT_YT_PLAYER_CLIENTS` leads with. The only real fallback left in the list is `web`/`web_embedded`, but per the existing comment in this file, those need a JS runtime to solve YouTube's signature/n-challenges. Even with a JS runtime installed, yt-dlp refuses to fetch its EJS challenge-solver script unless `--remote-components ejs:*` is explicitly allowed — so without this change, `web`/`web_embedded` silently yield no audio either, and the whole fallback chain effectively fails once SABR gates the first two clients. This matches #247 exactly (`Downtify 2.9.1 fails to download YouTube Music`), including the fix identified there (`yt-dlp --js-runtimes node --remote-components ejs:github`).

On a self-hosted instance, this showed up two ways: outright download failures (`FileNotFoundError` / `Unable to rename file...` in the logs), and — for tracks where some client did partially serve something — audio with an audible ~1s gap, presumably from a partial/mismatched stream.

## Verification

- Installed `deno`/`yt-dlp-ejs-rt-deno` and applied the `remote_components` change on the self-hosted instance and compared two 100-second log windows: **before** — several `FileNotFoundError`/`Unable to rename file` failures; **after** — zero failures (the `ios`/`android` SABR warnings are still present and expected, but the fallback chain now actually completes via a later client).
- Added `tests/test_downloader_extended.py::test_download_ydl_opts_enables_remote_ejs_component`, which monkeypatches `yt_dlp.YoutubeDL` to capture `ydl_opts` without any network access and asserts `remote_components == ['ejs:github']`. Confirmed it fails without the fix (removed the line locally, test failed with the expected `AssertionError: assert None == ['ejs:github']`) and passes with it.
- `make lint` / `ruff format` / `ruff check`: clean.
- `pytest -x -s -v`: full suite green (341 passed).
- Did not modify the yt-dlp version pin — saw `dependabot/uv/yt-dlp-2026.8.19` is already open and handles that separately.