### PR TITLE
Add CSV library import (Soundiiz, TuneMyMusic, Exportify)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ It resolves track metadata directly from Spotify's public embed pages, finds the
 | 🎨 **Rich metadata** | Album art, title, artist, album, year — all embedded in every file |
 | 🎚️ **Multiple formats** | MP3 · FLAC · M4A · OGG · OPUS |
 | 🔎 **Free-text search** | Search YouTube Music directly — no Spotify link needed |
+| 📥 **CSV library import** | Import a library export from Soundiiz, TuneMyMusic or Exportify and queue the whole thing |
 | 🔑 **Zero credentials** | No Spotify API key, no account, no Premium required |
 | 🔔 **Real-time progress** | Live download progress via WebSocket — no page reload needed |
 | 🐳 **One Docker command** | Up and running in under a minute |
@@ -200,6 +201,17 @@ When the setting is **off** (default), the existing behaviour is preserved: sing
 | Spotify playlist | ✅ |
 | YouTube Music search (free text) | ✅ |
 | Direct YouTube link | ✅ |
+
+---
+
+## 📥 Import a library CSV
+
+Already exported your library from [Soundiiz](https://soundiiz.com/), [TuneMyMusic](https://www.tunemymusic.com/) or [Exportify](https://github.com/watsonbox/exportify)? Click **"Import a library CSV"** below the search box on the home page and pick the file — Downtify reads its Title/Artist columns (it recognizes the column names each of those tools uses) and queues every track for download, resolving each one via YouTube Music search just like a free-text query.
+
+- The whole file is read in your browser and sent as plain text — nothing is uploaded anywhere else.
+- Rows are matched case-insensitively against common header names, so exports from any of the three tools work without renaming columns.
+- If a header can't be recognized, the import is rejected up front with the column names it did find, rather than silently skipping everything.
+- Combine this with **Settings → Delay between downloads** (see below) if you're importing a large library — Downtify will otherwise fire off a lot of YouTube requests back-to-back, which is an easy way to get rate-limited.
 
 ---
 

--- a/downtify/api.py
+++ b/downtify/api.py
@@ -26,6 +26,10 @@ working without changes:
 * ``POST /api/download/album`` (YouTube Music album/browse URL only;
   downloads every track from one shared, already-resolved tracklist so
   metadata stays consistent across the whole release)
+* ``POST /api/download/csv`` (import a library-export CSV from Soundiiz,
+  TuneMyMusic, Exportify, etc.; JSON body ``{csv, playlist_name,
+  generate_m3u}`` - the raw CSV text, read client-side, not a multipart
+  upload)
 * ``POST /api/playlist/m3u``
 * ``GET  /api/settings``
 * ``POST /api/settings/update``
@@ -52,7 +56,7 @@ from fastapi import (
 )
 from loguru import logger
 
-from . import m3u, providers, spotify
+from . import library_import, m3u, providers, spotify
 from .downloader import Downloader
 from .monitor import PlaylistMonitorDB, check_playlist
 
@@ -509,12 +513,14 @@ async def _process_batch(
     job_ids: list[str],
     playlist_url: str,
     generate_m3u: bool,
+    playlist_name: Optional[str] = None,
 ) -> None:
     # Resolve the playlist name up-front so all tracks land in a single,
     # per-playlist sub-folder. Loose batches (e.g. albums or unrelated
-    # tracks) keep the legacy flat layout under download_dir.
+    # tracks) keep the legacy flat layout under download_dir. A caller
+    # without a Spotify playlist_url (e.g. a CSV library import) can
+    # instead pass playlist_name directly.
     playlist_subdir: Optional[str] = None
-    playlist_name: Optional[str] = None
     parsed = spotify.parse_spotify_url(playlist_url) if playlist_url else None
     if parsed is not None and parsed[0] == 'playlist':
         try:
@@ -526,6 +532,8 @@ async def _process_batch(
             logger.exception(
                 'Failed to resolve playlist name for {}', playlist_url
             )
+    elif playlist_name:
+        playlist_subdir = m3u.sanitize_playlist_name(playlist_name)
 
     # A per-song delay only makes sense when there's a "next" song to
     # wait for; skip it entirely for a lone track so a single download
@@ -636,6 +644,79 @@ async def download_batch_endpoint(request: Request) -> dict[str, Any]:
 
     task.add_done_callback(_log_batch_failure)
     return {'job_ids': job_ids, 'count': len(job_ids)}
+
+
+@router.post('/api/download/csv')
+async def download_csv_endpoint(request: Request) -> dict[str, Any]:
+    """Import a library-export CSV (Soundiiz, TuneMyMusic, Exportify, ...).
+
+    Body: ``{"csv": "<raw file text>", "playlist_name": "...",
+    "generate_m3u": true}``. The CSV is read client-side and sent as
+    plain text in the JSON body rather than as a multipart upload, to
+    match every other endpoint here and avoid an extra dependency.
+
+    Each row is resolved the same way a free-text search would be, via
+    :func:`providers.find_match` inside :meth:`Downloader.download` -
+    there is no Spotify/YouTube URL per row, only a title and artist.
+    """
+    if state.downloader is None:
+        raise HTTPException(status_code=500, detail='Downloader not ready')
+
+    try:
+        payload = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail='Invalid JSON') from exc
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail='Invalid payload')
+
+    csv_text = payload.get('csv')
+    if not isinstance(csv_text, str) or not csv_text.strip():
+        raise HTTPException(
+            status_code=400, detail='csv must be a non-empty string'
+        )
+
+    try:
+        songs = await asyncio.to_thread(
+            library_import.parse_library_csv, csv_text
+        )
+    except library_import.LibraryCsvError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    playlist_name = (
+        str(payload.get('playlist_name') or '').strip() or 'Imported Library'
+    )
+    generate_m3u = bool(payload.get('generate_m3u', True))
+
+    job_ids: list[str] = []
+    for song in songs:
+        song_id = _register_job(song, status='queued')
+        job_ids.append(song_id)
+        await state.connections.broadcast({
+            'song': song,
+            'progress': 0,
+            'message': '',
+            'status': 'queued',
+        })
+
+    task = asyncio.create_task(
+        _process_batch(
+            songs, job_ids, '', generate_m3u, playlist_name=playlist_name
+        )
+    )
+
+    def _log_batch_failure(t: asyncio.Task) -> None:
+        if t.cancelled():
+            return
+        exc = t.exception()
+        if exc is not None:
+            logger.opt(exception=exc).error('CSV batch processing crashed')
+
+    task.add_done_callback(_log_batch_failure)
+    return {
+        'job_ids': job_ids,
+        'count': len(job_ids),
+        'playlist_name': playlist_name,
+    }
 
 
 def _songs_for_album_download(url: str) -> list[dict[str, Any]]:

--- a/downtify/library_import.py
+++ b/downtify/library_import.py
@@ -1,0 +1,123 @@
+"""Parse library-export CSV files (Soundiiz, TuneMyMusic, Exportify, ...)
+into song dicts the download pipeline can resolve.
+
+These tools all export "one row per track" CSVs, but use different column
+names for the same data (e.g. Exportify's ``Track Name`` / ``Artist
+Name(s)`` vs. a plain ``Title`` / ``Artist``). Rather than hard-coding one
+tool's schema, headers are matched case-insensitively against a set of
+known aliases, so the same importer works across exporters without the
+user needing to rename columns.
+
+Only title and artist are read. Other columns some exporters include
+(album, ISRC, a Spotify track URI, duration) aren't used here — the
+importer intentionally sticks to the exact "track + artist" scope the
+feature was requested for; each row still goes through the same
+YouTube-Music matching (:func:`downtify.providers.find_match`) that a
+free-text search does today.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import re
+from typing import Any
+
+MAX_CSV_ROWS = 2000
+
+_TITLE_HEADERS = {
+    'title',
+    'track',
+    'track title',
+    'track name',
+    'song',
+    'song title',
+    'song name',
+    'name',
+}
+_ARTIST_HEADERS = {
+    'artist',
+    'artists',
+    'artist name',
+    'artist name(s)',
+    'track artist',
+    'song artist',
+    'performer',
+}
+
+_ARTIST_SPLIT_RE = re.compile(r'[,;]')
+
+
+class LibraryCsvError(ValueError):
+    """Raised when a CSV can't be parsed into track/artist rows."""
+
+
+def _find_column(fieldnames: list[str], aliases: set[str]) -> str | None:
+    for name in fieldnames:
+        if name and name.strip().lower() in aliases:
+            return name
+    return None
+
+
+def _sniff_dialect(sample: str) -> type[csv.Dialect]:
+    try:
+        return csv.Sniffer().sniff(sample, delimiters=',;\t')
+    except csv.Error:
+        return csv.excel
+
+
+def parse_library_csv(text: str) -> list[dict[str, Any]]:
+    """Parse *text* (a CSV file's decoded content) into song dicts.
+
+    Each returned dict has ``name`` (track title), ``artists`` (a list
+    of one or more artist names), and a synthetic ``song_id`` (``csv:0``,
+    ``csv:1``, ...). ``name``/``artists`` are the minimum shape
+    :meth:`downtify.downloader.Downloader.download` needs to resolve a
+    track via YouTube Music search when no direct video/Spotify URL is
+    known; ``song_id`` exists because the frontend's queue/progress
+    tracking keys every song by it and would otherwise conflate every
+    CSV row into a single entry.
+
+    Raises :class:`LibraryCsvError` when the file has no rows, or its
+    header doesn't contain a recognizable title and artist column, or
+    it exceeds :data:`MAX_CSV_ROWS` rows (a sanity cap, not a real-world
+    library size limit).
+    """
+    dialect = _sniff_dialect(text[:4096])
+    reader = csv.DictReader(io.StringIO(text), dialect=dialect)
+    fieldnames = reader.fieldnames or []
+    title_col = _find_column(fieldnames, _TITLE_HEADERS)
+    artist_col = _find_column(fieldnames, _ARTIST_HEADERS)
+    if not title_col or not artist_col:
+        raise LibraryCsvError(
+            'Could not find title/artist columns in the CSV. '
+            f'Columns found: {", ".join(fieldnames) or "(none)"}'
+        )
+
+    songs: list[dict[str, Any]] = []
+    for row in reader:
+        if len(songs) >= MAX_CSV_ROWS:
+            raise LibraryCsvError(
+                f'CSV has more than {MAX_CSV_ROWS} rows; split it into '
+                'smaller files and import them separately.'
+            )
+        title = (row.get(title_col) or '').strip()
+        artist_field = (row.get(artist_col) or '').strip()
+        if not title or not artist_field:
+            continue
+        artists = [
+            a.strip()
+            for a in _ARTIST_SPLIT_RE.split(artist_field)
+            if a.strip()
+        ]
+        if not artists:
+            continue
+        songs.append({
+            'song_id': f'csv:{len(songs)}',
+            'name': title,
+            'artists': artists,
+        })
+
+    if not songs:
+        raise LibraryCsvError('No track/artist rows found in the CSV.')
+    return songs

--- a/frontend/src/components/Hero.vue
+++ b/frontend/src/components/Hero.vue
@@ -51,6 +51,32 @@
             {{ t('hero.playlists') }}</span
           >
         </div>
+
+        <div class="mt-5">
+          <button
+            type="button"
+            class="inline-flex items-center gap-1.5 text-xs text-base-content/50 hover:text-base-content/80 transition-colors"
+            :disabled="importing"
+            @click="triggerCsvPicker"
+          >
+            <span
+              v-if="importing"
+              class="loading loading-spinner loading-xs"
+            ></span>
+            <Icon v-else icon="clarity:import-line" class="h-3.5 w-3.5" />
+            {{ t('hero.importCsv') }}
+          </button>
+          <input
+            ref="csvInput"
+            type="file"
+            accept=".csv,text/csv"
+            class="hidden"
+            @change="onCsvSelected"
+          />
+          <p v-if="importError" class="mt-2 text-xs text-error">
+            {{ importError }}
+          </p>
+        </div>
       </div>
     </div>
   </section>
@@ -58,7 +84,10 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import { Icon } from '@iconify/vue'
 import SearchInput from './SearchInput.vue'
+import router from '../router'
+import { useDownloadManager } from '../model/download'
 import { useI18n } from '../i18n'
 
 const { t } = useI18n()
@@ -67,4 +96,36 @@ onMounted(() => {
   const v = localStorage.getItem('version')
   if (v) version.value = v
 })
+
+const dm = useDownloadManager()
+const csvInput = ref(null)
+const importing = ref(false)
+const importError = ref('')
+
+function triggerCsvPicker() {
+  importError.value = ''
+  csvInput.value?.click()
+}
+
+function onCsvSelected(event) {
+  const file = event.target.files && event.target.files[0]
+  event.target.value = ''
+  if (!file) return
+
+  importError.value = ''
+  importing.value = true
+  const playlistName = file.name.replace(/\.csv$/i, '')
+  dm.fromCsvFile(file, playlistName)
+    .then(() => {
+      router.push({ name: 'Download' })
+    })
+    .catch((err) => {
+      console.log('CSV import failed:', err.message)
+      importError.value =
+        err?.response?.data?.detail || t('hero.importCsvError')
+    })
+    .finally(() => {
+      importing.value = false
+    })
+}
 </script>

--- a/frontend/src/i18n/locales/el.js
+++ b/frontend/src/i18n/locales/el.js
@@ -31,6 +31,8 @@ export default {
     songs: 'Τραγούδια',
     albums: 'Άλμπουμ',
     playlists: 'Λίστες αναπαραγωγής',
+    importCsv: 'Εισαγωγή CSV βιβλιοθήκης (Soundiiz, TuneMyMusic, Exportify…)',
+    importCsvError: 'Δεν ήταν δυνατή η εισαγωγή αυτού του αρχείου CSV.',
   },
   search: {
     placeholder: 'Αναζήτηση, επικόλληση συνδέσμου Spotify ή YouTube Music...',

--- a/frontend/src/i18n/locales/en.js
+++ b/frontend/src/i18n/locales/en.js
@@ -31,6 +31,8 @@ export default {
     songs: 'Songs',
     albums: 'Albums',
     playlists: 'Playlists',
+    importCsv: 'Import a library CSV (Soundiiz, TuneMyMusic, Exportify…)',
+    importCsvError: "Couldn't import that CSV file.",
   },
   search: {
     placeholder: 'Search, paste a Spotify or YouTube Music link…',

--- a/frontend/src/i18n/locales/es.js
+++ b/frontend/src/i18n/locales/es.js
@@ -31,6 +31,9 @@ export default {
     songs: 'Canciones',
     albums: 'Álbumes',
     playlists: 'Listas',
+    importCsv:
+      'Importar un CSV de biblioteca (Soundiiz, TuneMyMusic, Exportify…)',
+    importCsvError: 'No se pudo importar ese archivo CSV.',
   },
   search: {
     placeholder: 'Busca o pega un enlace de Spotify o YouTube Music…',

--- a/frontend/src/i18n/locales/fr.js
+++ b/frontend/src/i18n/locales/fr.js
@@ -31,6 +31,9 @@ export default {
     songs: 'Titres',
     albums: 'Albums',
     playlists: 'Listes de lecture',
+    importCsv:
+      'Importer un CSV de bibliothèque (Soundiiz, TuneMyMusic, Exportify…)',
+    importCsvError: "Impossible d'importer ce fichier CSV.",
   },
   search: {
     placeholder: 'Recherchez, collez un lien Spotify ou YouTube Music…',

--- a/frontend/src/i18n/locales/hu.js
+++ b/frontend/src/i18n/locales/hu.js
@@ -31,6 +31,8 @@ export default {
     songs: 'Zenék',
     albums: 'Albumok',
     playlists: 'Lejátszási listák',
+    importCsv: 'Könyvtár CSV importálása (Soundiiz, TuneMyMusic, Exportify…)',
+    importCsvError: 'Nem sikerült importálni ezt a CSV fájlt.',
   },
   search: {
     placeholder: 'Keresés, illessz be egy Spotify vagy YouTube Music linket…',

--- a/frontend/src/i18n/locales/pt-BR.js
+++ b/frontend/src/i18n/locales/pt-BR.js
@@ -31,6 +31,9 @@ export default {
     songs: 'Músicas',
     albums: 'Álbuns',
     playlists: 'Playlists',
+    importCsv:
+      'Importar um CSV de biblioteca (Soundiiz, TuneMyMusic, Exportify…)',
+    importCsvError: 'Não foi possível importar esse arquivo CSV.',
   },
   search: {
     placeholder:

--- a/frontend/src/i18n/locales/tr.js
+++ b/frontend/src/i18n/locales/tr.js
@@ -31,6 +31,9 @@ export default {
     songs: 'Şarkılar',
     albums: 'Albümler',
     playlists: 'Çalma Listeleri',
+    importCsv:
+      'Bir kütüphane CSV dosyası içe aktar (Soundiiz, TuneMyMusic, Exportify…)',
+    importCsvError: 'Bu CSV dosyası içe aktarılamadı.',
   },
   search: {
     placeholder:

--- a/frontend/src/model/api.js
+++ b/frontend/src/model/api.js
@@ -67,6 +67,10 @@ function downloadBatch(payload) {
   return API.post('/api/download/batch', payload)
 }
 
+function downloadCsv(payload) {
+  return API.post('/api/download/csv', payload)
+}
+
 function check_for_update() {
   return API.get('/api/check_update')
 }
@@ -135,6 +139,7 @@ export default {
   open,
   download,
   downloadBatch,
+  downloadCsv,
   downloadFileURL,
   coverFileURL,
   listDownloads,

--- a/frontend/src/model/download.js
+++ b/frontend/src/model/download.js
@@ -196,6 +196,35 @@ export function useDownloadManager() {
       })
   }
 
+  function _readFileAsText(file) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => resolve(String(reader.result || ''))
+      reader.onerror = () => reject(reader.error || new Error('Read failed'))
+      reader.readAsText(file)
+    })
+  }
+
+  function fromCsvFile(file, playlistName) {
+    const generateM3u = settingsManager.settings.value.generate_m3u !== false
+    loading.value = true
+    return _readFileAsText(file)
+      .then((csv) =>
+        API.downloadCsv({
+          csv,
+          playlist_name: playlistName || '',
+          generate_m3u: generateM3u,
+        })
+      )
+      .then((res) => {
+        console.log('CSV import queued:', res.data)
+        return res.data
+      })
+      .finally(() => {
+        loading.value = false
+      })
+  }
+
   function download(song) {
     console.log('Downloading', song)
     progressTracker.getBySong(song).setDownloading()
@@ -277,6 +306,7 @@ export function useDownloadManager() {
 
   return {
     fromURL,
+    fromCsvFile,
     download,
     queue,
     retryWithAudio,

--- a/tests/test_api_download_csv.py
+++ b/tests/test_api_download_csv.py
@@ -1,0 +1,205 @@
+"""Tests for POST /api/download/csv - importing a library-export CSV."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from downtify import api
+
+
+class _StubDownloader:
+    download_dir = Path('/tmp/downtify-test-downloads')
+
+
+class _FakeRequest:
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+
+def _run(monkeypatch, payload, *, downloader=object()):
+    monkeypatch.setattr(api.state, 'downloader', downloader)
+    monkeypatch.setattr(api.state, 'download_jobs', {})
+    captured_batches = []
+
+    async def fake_process_batch(
+        songs, job_ids, playlist_url, generate_m3u, playlist_name=None
+    ):
+        captured_batches.append({
+            'songs': songs,
+            'job_ids': job_ids,
+            'playlist_url': playlist_url,
+            'generate_m3u': generate_m3u,
+            'playlist_name': playlist_name,
+        })
+
+    monkeypatch.setattr(api, '_process_batch', fake_process_batch)
+
+    async def _invoke():
+        result = await api.download_csv_endpoint(_FakeRequest(payload))
+        # _process_batch runs as a background task (asyncio.create_task);
+        # yield back to the loop so it actually runs before we assert.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        return result
+
+    result = asyncio.run(_invoke())
+    return result, captured_batches
+
+
+def test_download_csv_requires_downloader(monkeypatch):
+    monkeypatch.setattr(api.state, 'downloader', None)
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(api.download_csv_endpoint(_FakeRequest({'csv': 'x'})))
+    assert exc_info.value.status_code == 500
+
+
+def test_download_csv_rejects_missing_csv_field(monkeypatch):
+    monkeypatch.setattr(api.state, 'downloader', object())
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(api.download_csv_endpoint(_FakeRequest({})))
+    assert exc_info.value.status_code == 400
+
+
+def test_download_csv_rejects_blank_csv(monkeypatch):
+    monkeypatch.setattr(api.state, 'downloader', object())
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(api.download_csv_endpoint(_FakeRequest({'csv': '   '})))
+    assert exc_info.value.status_code == 400
+
+
+def test_download_csv_rejects_unparsable_csv(monkeypatch):
+    monkeypatch.setattr(api.state, 'downloader', object())
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            api.download_csv_endpoint(_FakeRequest({'csv': 'Foo,Bar\n1,2\n'}))
+        )
+    assert exc_info.value.status_code == 400
+
+
+def test_download_csv_queues_every_row(monkeypatch):
+    csv_text = 'Title,Artist\nSong A,Artist A\nSong B,Artist B\n'
+    result, batches = _run(monkeypatch, {'csv': csv_text})
+    assert result['count'] == 2
+    assert len(result['job_ids']) == 2
+    assert len(batches) == 1
+    songs = batches[0]['songs']
+    assert songs == [
+        {'song_id': 'csv:0', 'name': 'Song A', 'artists': ['Artist A']},
+        {'song_id': 'csv:1', 'name': 'Song B', 'artists': ['Artist B']},
+    ]
+    # job_ids must track the (unique) song_id per row, not collide.
+    assert result['job_ids'] == ['csv:0', 'csv:1']
+
+
+def test_download_csv_defaults_playlist_name(monkeypatch):
+    csv_text = 'Title,Artist\nSong A,Artist A\n'
+    result, batches = _run(monkeypatch, {'csv': csv_text})
+    assert result['playlist_name'] == 'Imported Library'
+    assert batches[0]['playlist_name'] == 'Imported Library'
+
+
+def test_download_csv_honors_custom_playlist_name(monkeypatch):
+    csv_text = 'Title,Artist\nSong A,Artist A\n'
+    result, batches = _run(
+        monkeypatch, {'csv': csv_text, 'playlist_name': 'My Old Library'}
+    )
+    assert result['playlist_name'] == 'My Old Library'
+    assert batches[0]['playlist_name'] == 'My Old Library'
+
+
+def test_download_csv_passes_no_spotify_playlist_url(monkeypatch):
+    csv_text = 'Title,Artist\nSong A,Artist A\n'
+    _, batches = _run(monkeypatch, {'csv': csv_text})
+    assert not batches[0]['playlist_url']
+
+
+def test_download_csv_honors_generate_m3u_flag(monkeypatch):
+    csv_text = 'Title,Artist\nSong A,Artist A\n'
+    _, batches = _run(monkeypatch, {'csv': csv_text, 'generate_m3u': False})
+    assert batches[0]['generate_m3u'] is False
+
+
+def test_download_csv_registers_jobs_for_every_row(monkeypatch):
+    csv_text = 'Title,Artist\nSong A,Artist A\nSong B,Artist B\n'
+    result, _ = _run(monkeypatch, {'csv': csv_text})
+    for job_id in result['job_ids']:
+        assert job_id in api.state.download_jobs
+        assert api.state.download_jobs[job_id]['status'] == 'queued'
+
+
+# ── _process_batch with an explicit playlist_name (no Spotify URL) ─────────
+
+
+def test_process_batch_writes_m3u_under_explicit_playlist_name(monkeypatch):
+    """CSV imports have no Spotify playlist_url to resolve a name from;
+    _process_batch must accept an explicit playlist_name instead and
+    still group tracks into that playlist's subfolder / M3U."""
+    monkeypatch.setattr(api.state, 'downloader', _StubDownloader())
+    monkeypatch.setattr(api.state, 'download_jobs', {})
+    monkeypatch.setattr(api, '_organize_enabled', lambda: False)
+
+    async def fake_run_download(song, song_id, subdir=None, delay_seconds=0):
+        return f'{song["name"]}.mp3'
+
+    monkeypatch.setattr(api, '_run_download', fake_run_download)
+
+    written = {}
+
+    def fake_write_m3u(
+        download_dir, playlist_name, entries, *, playlist_subdir=None
+    ):
+        written['playlist_name'] = playlist_name
+        written['playlist_subdir'] = playlist_subdir
+        written['entries'] = list(entries)
+        return download_dir / 'Playlists' / f'{playlist_name}.m3u', len(
+            written['entries']
+        )
+
+    monkeypatch.setattr(api.m3u, 'write_m3u', fake_write_m3u)
+
+    songs = [
+        {'name': 'Song A', 'artists': ['Artist A']},
+        {'name': 'Song B', 'artists': ['Artist B']},
+    ]
+    asyncio.run(
+        api._process_batch(
+            songs,
+            ['job-a', 'job-b'],
+            playlist_url='',
+            generate_m3u=True,
+            playlist_name='My Old Library',
+        )
+    )
+
+    assert written['playlist_name'] == 'My Old Library'
+    assert written['playlist_subdir'] == 'My Old Library'
+    assert len(written['entries']) == 2
+
+
+def test_process_batch_skips_m3u_when_playlist_name_missing(monkeypatch):
+    monkeypatch.setattr(api.state, 'downloader', object())
+    monkeypatch.setattr(api.state, 'download_jobs', {})
+
+    async def fake_run_download(song, song_id, subdir=None, delay_seconds=0):
+        return f'{song["name"]}.mp3'
+
+    monkeypatch.setattr(api, '_run_download', fake_run_download)
+
+    def fake_write_m3u(*_a, **_kw):
+        raise AssertionError('should not write an M3U with no playlist name')
+
+    monkeypatch.setattr(api.m3u, 'write_m3u', fake_write_m3u)
+
+    songs = [{'name': 'Song A', 'artists': ['Artist A']}]
+    asyncio.run(
+        api._process_batch(
+            songs, ['job-a'], playlist_url='', generate_m3u=True
+        )
+    )

--- a/tests/test_library_import.py
+++ b/tests/test_library_import.py
@@ -1,0 +1,173 @@
+"""Tests for downtify/library_import.py: parsing library-export CSVs
+(Soundiiz, TuneMyMusic, Exportify, ...) into title/artist song dicts."""
+
+from __future__ import annotations
+
+import pytest
+
+from downtify.library_import import (
+    MAX_CSV_ROWS,
+    LibraryCsvError,
+    parse_library_csv,
+)
+
+# ── header detection across exporters ───────────────────────────────────────
+
+
+def test_parses_simple_title_artist_headers():
+    csv_text = 'Title,Artist\nHeld Together,Slowdive\nFallen Wires,DIIV\n'
+    songs = parse_library_csv(csv_text)
+    assert songs == [
+        {'song_id': 'csv:0', 'name': 'Held Together', 'artists': ['Slowdive']},
+        {'song_id': 'csv:1', 'name': 'Fallen Wires', 'artists': ['DIIV']},
+    ]
+
+
+def test_parses_exportify_style_headers():
+    csv_text = (
+        'Track URI,Track Name,Artist Name(s),Album Name\n'
+        'spotify:track:abc,Space Song,Beach House,Depression Cherry\n'
+    )
+    songs = parse_library_csv(csv_text)
+    assert songs == [
+        {'song_id': 'csv:0', 'name': 'Space Song', 'artists': ['Beach House']}
+    ]
+
+
+def test_parses_tunemymusic_style_headers():
+    csv_text = (
+        'Track Title,Artist,Album,Playlist Name\n'
+        'Motion Picture Soundtrack,Radiohead,Kid A,Favorites\n'
+    )
+    songs = parse_library_csv(csv_text)
+    assert songs == [
+        {
+            'song_id': 'csv:0',
+            'name': 'Motion Picture Soundtrack',
+            'artists': ['Radiohead'],
+        }
+    ]
+
+
+def test_header_matching_is_case_insensitive():
+    csv_text = 'TITLE,ARTIST\nSong One,Artist One\n'
+    songs = parse_library_csv(csv_text)
+    assert songs == [
+        {'song_id': 'csv:0', 'name': 'Song One', 'artists': ['Artist One']}
+    ]
+
+
+def test_semicolon_delimited_csv_is_sniffed():
+    csv_text = 'Title;Artist\nSong One;Artist One\n'
+    songs = parse_library_csv(csv_text)
+    assert songs == [
+        {'song_id': 'csv:0', 'name': 'Song One', 'artists': ['Artist One']}
+    ]
+
+
+# ── song_id ──────────────────────────────────────────────────────────────────
+
+
+def test_song_ids_are_unique_and_sequential():
+    csv_text = 'Title,Artist\nA,Artist A\nB,Artist B\nC,Artist C\n'
+    songs = parse_library_csv(csv_text)
+    assert [s['song_id'] for s in songs] == ['csv:0', 'csv:1', 'csv:2']
+
+
+def test_song_ids_stay_sequential_when_invalid_rows_are_skipped():
+    # The frontend keys every download queue item by song_id, and would
+    # conflate two rows sharing one id into a single queue entry — so a
+    # skipped row (missing title/artist) must not leave a gap that later
+    # collides, and IDs must simply follow the surviving rows in order.
+    csv_text = 'Title,Artist\nA,Artist A\n,Missing Title\nB,Artist B\n'
+    songs = parse_library_csv(csv_text)
+    assert [s['song_id'] for s in songs] == ['csv:0', 'csv:1']
+    assert [s['name'] for s in songs] == ['A', 'B']
+
+
+# ── multi-artist rows ────────────────────────────────────────────────────────
+
+
+def test_splits_multiple_artists_on_comma():
+    # The artist field itself contains a comma, so it must be quoted for
+    # the CSV parser to keep it as one column.
+    csv_text = 'Title,Artist\nCollab Song,"Artist A, Artist B"\n'
+    songs = parse_library_csv(csv_text)
+    assert songs == [
+        {
+            'song_id': 'csv:0',
+            'name': 'Collab Song',
+            'artists': ['Artist A', 'Artist B'],
+        }
+    ]
+
+
+def test_splits_multiple_artists_on_semicolon_within_quoted_field():
+    csv_text = 'Title,Artist\nCollab Song,"Artist A; Artist B"\n'
+    songs = parse_library_csv(csv_text)
+    assert songs == [
+        {
+            'song_id': 'csv:0',
+            'name': 'Collab Song',
+            'artists': ['Artist A', 'Artist B'],
+        }
+    ]
+
+
+# ── row filtering ────────────────────────────────────────────────────────────
+
+
+def test_skips_rows_missing_title_or_artist():
+    csv_text = (
+        'Title,Artist\nHas Both,Some Artist\n,Missing Title\nMissing Artist,\n'
+    )
+    songs = parse_library_csv(csv_text)
+    assert songs == [
+        {'song_id': 'csv:0', 'name': 'Has Both', 'artists': ['Some Artist']}
+    ]
+
+
+def test_strips_whitespace_from_title_and_artist():
+    csv_text = 'Title,Artist\n  Padded Title  ,  Padded Artist  \n'
+    songs = parse_library_csv(csv_text)
+    assert songs == [
+        {
+            'song_id': 'csv:0',
+            'name': 'Padded Title',
+            'artists': ['Padded Artist'],
+        }
+    ]
+
+
+# ── error cases ──────────────────────────────────────────────────────────────
+
+
+def test_raises_when_no_recognizable_columns():
+    csv_text = 'Foo,Bar\n1,2\n'
+    with pytest.raises(LibraryCsvError):
+        parse_library_csv(csv_text)
+
+
+def test_raises_when_empty():
+    with pytest.raises(LibraryCsvError):
+        parse_library_csv('')
+
+
+def test_raises_when_all_rows_invalid():
+    csv_text = 'Title,Artist\n,\n,\n'
+    with pytest.raises(LibraryCsvError):
+        parse_library_csv(csv_text)
+
+
+def test_raises_over_max_row_cap():
+    header = 'Title,Artist\n'
+    rows = ''.join(f'Song {i},Artist {i}\n' for i in range(MAX_CSV_ROWS + 1))
+    with pytest.raises(LibraryCsvError):
+        parse_library_csv(header + rows)
+
+
+def test_accepts_exactly_max_row_cap():
+    header = 'Title,Artist\n'
+    rows = ''.join(f'Song {i},Artist {i}\n' for i in range(MAX_CSV_ROWS))
+    songs = parse_library_csv(header + rows)
+    assert len(songs) == MAX_CSV_ROWS


### PR DESCRIPTION
Lets users import a library-export CSV from Soundiiz, TuneMyMusic or Exportify and queue the whole thing for download in one go, instead of re-adding tracks one at a time. Each row is resolved via the same YouTube Music search/matching the app already uses for free-text queries — there's no Spotify/YouTube URL per row, only a title and artist.

Backend:
- New downtify/library_import.py: parse_library_csv() turns a CSV's text into title/artist song dicts. Header names are matched case-insensitively against a set of aliases (Title/Track Name/Track Title/..., Artist/Artist Name(s)/...) so exports from any of the three tools work without column renaming; delimiter is sniffed (comma/semicolon/tab). Caps at 2000 rows and raises a clear LibraryCsvError (surfaced as an HTTP 400 with the columns it did find) when the header can't be recognized or no rows survive.
- Each parsed song gets a synthetic song_id ("csv:0", "csv:1", ...) - the frontend's queue/progress tracking keys every item by song_id, and rows have no natural one the way a Spotify/YouTube track does; without it every row would collide into a single queue entry.
- New POST /api/download/csv endpoint: takes {csv, playlist_name, generate_m3u} as JSON (the file is read client-side and sent as text, matching every other endpoint here, rather than a multipart upload - avoids adding python-multipart as a dependency). Reuses _process_batch, the same batch machinery already used by playlist downloads, so imported tracks get the existing concurrency limit, the delay-between-downloads setting, and M3U generation for free.
- _process_batch now accepts an explicit playlist_name, for callers (like this one) with no Spotify playlist_url to resolve a name from.

Frontend:
- Hero.vue: "Import a library CSV" link below the search box, opening a hidden file input; reads the file with FileReader and posts it, named after the file (minus .csv) as the playlist name. Surfaces the backend's error detail (e.g. unrecognized columns) inline.
- model/download.js: fromCsvFile(); model/api.js: downloadCsv().

Addresses the rate-limiting concern raised alongside the feature request by pointing at the existing "Delay between downloads" setting (added separately) rather than adding a second, redundant knob.

Verified manually against a running server: POST /api/download/csv with a real CSV correctly registers jobs with unique song_ids, queues them, and reaches the real YouTube-Music matching step (the only failure in this sandbox is "no match found", expected with no network egress to YouTube); malformed CSVs are rejected with a clear 400. Confirmed the built frontend bundle serves the new UI trigger.

close #204