### PR TITLE
Fix possible fix(deps): yt-dlp 2026.6.9 → 2026.7.4 (CVE-2026-55404) in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ websockets==16.0
     # via downtify
 win32-setctime==1.2.0 ; sys_platform == 'win32'
     # via loguru
-yt-dlp==2026.6.9
+yt-dlp==2026.7.4
     # via downtify
 ytmusicapi==1.12.1
     # via downtify


### PR DESCRIPTION
This changes `requirements.txt` to address something a scan flagged. It is around line 69.

High-severity vulnerability (CVE-2026-55404) in yt-dlp 2026.6.9. The --write-link, --write-url-link, and --write-desktop-link options generate .url/.desktop shortcut files using attacker-controlled metadata (webpage_url, filename) without validation. A malicious actor could inject file:// URIs (Windows) or newline-based key injection (Linux) into these shortcuts, potentially executing arbitrary commands when the generated shortcut file is opened. Since yt-dlp processes untrusted video URLs/metadata, any user downloading content with these options is exposed to command execution risk. Fix: upgrade to yt-dlp 2026.7.4 or later in requirements.txt (line 69).

Update yt-dlp to 2026.7.4 to resolve CVE-2026-55404

For reference: rule `CVE-2026-55404`. Rated high.

Take or leave whichever parts are useful. If this is not the right approach, closing is fine.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
