### PR TITLE
Feature/incremental m3u monitor

### DIFF
--- a/docs/features/m3u-export.md
+++ b/docs/features/m3u-export.md
@@ -23,12 +23,22 @@ Track paths inside the M3U are written **relative to the M3U file itself**, not 
 
 M3U generation is controlled by **Settings → Generate M3U file for playlists** (on by default). Turning it off skips M3U creation entirely; the rest of the download flow is unchanged.
 
+## When it is written
+
+The M3U is written **twice** per run — once as soon as the *first* track finishes downloading, and again when the run completes:
+
+| Run type | Early write | Final write |
+|----------|-------------|-------------|
+| Playlist / album download, [CSV import](library-import.md) | After the first track finishes | After every track finishes |
+| [Playlist Monitor](playlist-monitor.md#m3u-integration) sweep | After the first new track finishes | After the sweep completes |
+
+The early write means the playlist is already playable — and you can confirm the sync is working — without waiting for the whole batch. A single slow or hung download no longer keeps the M3U from appearing at all. The final write picks up everything else that downloaded.
+
+Both writes list tracks in **playlist order**, not in the order downloads happened to finish, so a partially-written M3U is still correctly ordered.
+
 ## Regeneration
 
-The M3U is regenerated fresh on every run:
-
-- Re-pasting the same playlist URL produces a complete, in-order file including any tracks that were missing on earlier runs
-- The Playlist Monitor regenerates the M3U after each sweep that downloads at least one new track
+The M3U is regenerated fresh on every run — re-pasting the same playlist URL produces a complete, in-order file including any tracks that were missing on earlier runs.
 
 Tracks that failed to download or had no YouTube Music match are silently skipped.
 

--- a/docs/features/m3u-export.md
+++ b/docs/features/m3u-export.md
@@ -25,16 +25,16 @@ M3U generation is controlled by **Settings → Generate M3U file for playlists**
 
 ## When it is written
 
-The M3U is written **twice** per run — once as soon as the *first* track finishes downloading, and again when the run completes:
+The M3U is rewritten **after every track finishes downloading**, so the playlist file grows as the download progresses instead of appearing all at once at the end. This applies to playlist and album downloads, [CSV imports](library-import.md) and [Playlist Monitor](playlist-monitor.md#m3u-integration) sweeps alike.
 
-| Run type | Early write | Final write |
-|----------|-------------|-------------|
-| Playlist / album download, [CSV import](library-import.md) | After the first track finishes | After every track finishes |
-| [Playlist Monitor](playlist-monitor.md#m3u-integration) sweep | After the first new track finishes | After the sweep completes |
+That means the playlist is playable from the moment the first track lands, you can see the sync is working as it goes, and a single slow or hung download can never keep the M3U — or the tracks that already finished — from showing up.
 
-The early write means the playlist is already playable — and you can confirm the sync is working — without waiting for the whole batch. A single slow or hung download no longer keeps the M3U from appearing at all. The final write picks up everything else that downloaded.
+A final rewrite runs once the whole run completes. It resolves every track against the filesystem (rather than the in-memory list of what this run downloaded), so it also picks up files from earlier runs and corrects anything that changed on disk mid-run.
 
-Both writes list tracks in **playlist order**, not in the order downloads happened to finish, so a partially-written M3U is still correctly ordered.
+Every write lists tracks in **playlist order**, not in the order downloads happened to finish, so a partially-written M3U is still correctly ordered.
+
+!!! note "Tracks already on disk"
+    Tracks downloaded by an earlier run stay in the M3U throughout — they're included from the first write, not only added by the final one.
 
 ## Regeneration
 

--- a/docs/features/playlist-monitor.md
+++ b/docs/features/playlist-monitor.md
@@ -77,7 +77,9 @@ Playlist embed entries are missing the release year and use the playlist cover a
 
 ## M3U integration
 
-After each sweep that downloads at least one new track, Downtify regenerates the playlist's M3U file to reflect the current on-disk state. See [M3U Export](m3u-export.md) for details.
+The M3U is written **twice** per sweep that downloads at least one new track: once right after the *first* track finishes, and again once the sweep completes. The early write means the playlist is already playable — and you can confirm the sync is working — without waiting for every track to finish; a slow or hung download further down the list no longer holds up the whole M3U. The final write picks up every track that downloaded during the sweep.
+
+Manual playlist/album downloads and CSV imports behave the same way. See [M3U Export](m3u-export.md#when-it-is-written) for details.
 
 ## Storage
 

--- a/docs/features/playlist-monitor.md
+++ b/docs/features/playlist-monitor.md
@@ -77,7 +77,7 @@ Playlist embed entries are missing the release year and use the playlist cover a
 
 ## M3U integration
 
-The M3U is written **twice** per sweep that downloads at least one new track: once right after the *first* track finishes, and again once the sweep completes. The early write means the playlist is already playable — and you can confirm the sync is working — without waiting for every track to finish; a slow or hung download further down the list no longer holds up the whole M3U. The final write picks up every track that downloaded during the sweep.
+The playlist's M3U is rewritten **after every track finishes**, so it grows as the sweep downloads rather than appearing only once everything is done. The playlist is playable from the first track onwards, and a slow or hung download further down the list never holds up the tracks that already landed. A final rewrite at the end of the sweep re-resolves everything against the filesystem.
 
 Manual playlist/album downloads and CSV imports behave the same way. See [M3U Export](m3u-export.md#when-it-is-written) for details.
 

--- a/downtify/api.py
+++ b/downtify/api.py
@@ -508,6 +508,56 @@ async def download_endpoint(
     return filename
 
 
+def _m3u_entries_for(
+    songs: list[dict[str, Any]], resolved: dict[int, Optional[str]]
+) -> list[dict[str, Any]]:
+    """Build M3U entries for the songs downloaded so far.
+
+    Iterates ``songs`` in playlist order (not completion order, which
+    varies with concurrency) and keeps only those with a filename in
+    ``resolved``, so a partially-finished batch still produces a
+    correctly-ordered file.
+    """
+    entries: list[dict[str, Any]] = []
+    for index, song in enumerate(songs):
+        filename = resolved.get(index)
+        if not filename:
+            continue
+        entries.append({
+            'filename': filename,
+            'title': song.get('name') or '',
+            'artist': ', '.join(song.get('artists') or []),
+            'duration': song.get('duration') or 0,
+        })
+    return entries
+
+
+async def _write_batch_m3u(
+    songs: list[dict[str, Any]],
+    resolved: dict[int, Optional[str]],
+    playlist_name: str,
+    playlist_subdir: str,
+) -> None:
+    entries = _m3u_entries_for(songs, resolved)
+    if not entries:
+        return
+    # When organize-by-artist/album is on, songs land in those folders
+    # instead of the playlist subfolder, so the M3U must go to the legacy
+    # Playlists/ directory (playlist_subdir=None) where relative paths
+    # still resolve.
+    organize = _organize_enabled()
+    try:
+        await asyncio.to_thread(
+            m3u.write_m3u,
+            state.downloader.download_dir,
+            playlist_name,
+            entries,
+            playlist_subdir=None if organize else playlist_subdir,
+        )
+    except Exception:
+        logger.exception('Failed to write M3U for {!r}', playlist_name)
+
+
 async def _process_batch(
     songs: list[dict[str, Any]],
     job_ids: list[str],
@@ -544,7 +594,16 @@ async def _process_batch(
         else 0
     )
 
-    async def _bounded(song: dict[str, Any], song_id: str) -> dict[str, Any]:
+    wants_m3u = bool(generate_m3u and playlist_subdir and playlist_name)
+    # Filename per song index, filled in as downloads land. Used to write
+    # the M3U before the whole batch is done, so one slow or hung track
+    # can't hold up a playlist that's otherwise already on disk.
+    resolved: dict[int, Optional[str]] = {}
+    early_m3u_written = False
+    m3u_lock = asyncio.Lock()
+
+    async def _bounded(index: int, song: dict[str, Any], song_id: str) -> None:
+        nonlocal early_m3u_written
         try:
             filename = await _run_download(
                 song,
@@ -554,45 +613,27 @@ async def _process_batch(
             )
         except Exception:
             filename = None
-        return {'song': song, 'filename': filename}
+        resolved[index] = filename
+        if not (filename and wants_m3u):
+            return
+        async with m3u_lock:
+            if early_m3u_written:
+                return
+            early_m3u_written = True
+            await _write_batch_m3u(
+                songs, resolved, playlist_name, playlist_subdir
+            )
 
-    results = await asyncio.gather(
-        *[_bounded(s, sid) for s, sid in zip(songs, job_ids)],
+    await asyncio.gather(
+        *[
+            _bounded(i, s, sid)
+            for i, (s, sid) in enumerate(zip(songs, job_ids))
+        ],
         return_exceptions=False,
     )
 
-    if not (generate_m3u and playlist_subdir and playlist_name):
-        return
-
-    entries: list[dict[str, Any]] = []
-    for r in results:
-        if not r or not r.get('filename'):
-            continue
-        s = r['song']
-        entries.append({
-            'filename': r['filename'],
-            'title': s.get('name') or '',
-            'artist': ', '.join(s.get('artists') or []),
-            'duration': s.get('duration') or 0,
-        })
-    if not entries:
-        return
-
-    # When organize-by-artist/album is on, songs land in those folders
-    # instead of the playlist subfolder, so the M3U must go to the legacy
-    # Playlists/ directory (playlist_subdir=None) where relative paths
-    # still resolve.
-    organize = _organize_enabled()
-    try:
-        await asyncio.to_thread(
-            m3u.write_m3u,
-            state.downloader.download_dir,
-            playlist_name,
-            entries,
-            playlist_subdir=None if organize else playlist_subdir,
-        )
-    except Exception:
-        logger.exception('Failed to write M3U for {}', playlist_url)
+    if wants_m3u:
+        await _write_batch_m3u(songs, resolved, playlist_name, playlist_subdir)
 
 
 @router.post('/api/download/batch')

--- a/downtify/api.py
+++ b/downtify/api.py
@@ -595,15 +595,14 @@ async def _process_batch(
     )
 
     wants_m3u = bool(generate_m3u and playlist_subdir and playlist_name)
-    # Filename per song index, filled in as downloads land. Used to write
-    # the M3U before the whole batch is done, so one slow or hung track
-    # can't hold up a playlist that's otherwise already on disk.
+    # Filename per song index, filled in as downloads land. The M3U is
+    # rewritten from this after every completed download, so the playlist
+    # grows as it downloads instead of appearing all at once at the end,
+    # and one slow or hung track can't hold up what's already on disk.
     resolved: dict[int, Optional[str]] = {}
-    early_m3u_written = False
     m3u_lock = asyncio.Lock()
 
     async def _bounded(index: int, song: dict[str, Any], song_id: str) -> None:
-        nonlocal early_m3u_written
         try:
             filename = await _run_download(
                 song,
@@ -616,10 +615,9 @@ async def _process_batch(
         resolved[index] = filename
         if not (filename and wants_m3u):
             return
+        # Serialized so concurrent downloads can't interleave writes to
+        # the same file.
         async with m3u_lock:
-            if early_m3u_written:
-                return
-            early_m3u_written = True
             await _write_batch_m3u(
                 songs, resolved, playlist_name, playlist_subdir
             )

--- a/downtify/monitor.py
+++ b/downtify/monitor.py
@@ -303,6 +303,13 @@ async def check_playlist(
 
     pl_subdir = m3u.sanitize_playlist_name(playlist.name)
 
+    # Filenames already on disk from earlier sweeps, keyed by track id,
+    # topped up as each new track lands. Lets the M3U be rewritten after
+    # every single download without re-resolving the whole playlist
+    # against the filesystem each time (which is O(tracks) globs per
+    # write, and quadratic over a large sweep).
+    resolved: dict[str, str] = {}
+
     new_tracks = []
     for t in tracks:
         if not t.get('song_id'):
@@ -312,12 +319,13 @@ async def check_playlist(
             new_tracks.append(t)
         else:
             stored = known_tracks[tid]
-            if (
-                stored is not None
-                and not (downloader.download_dir / stored).exists()
-            ):
+            if stored is None:
+                continue
+            if not (downloader.download_dir / stored).exists():
                 # File was deleted — re-download
                 new_tracks.append(t)
+            else:
+                resolved[tid] = stored
 
     if new_tracks:
         logger.info(
@@ -327,7 +335,6 @@ async def check_playlist(
         )
 
     delay_seconds = (settings or {}).get('download_delay_seconds', 0) or 0
-    wrote_early_m3u = False
 
     downloaded = 0
     for index, song in enumerate(new_tracks):
@@ -382,18 +389,15 @@ async def check_playlist(
                 db.mark_track_downloaded, playlist.id, track_id, filename
             )
             downloaded += 1
-            if not wrote_early_m3u and (
-                settings is None or settings.get('generate_m3u', True)
-            ):
-                # Write the M3U as soon as the first track lands rather
-                # than waiting for the whole sweep, so a slow/hung
-                # download further down the list doesn't hold up an
-                # already-downloaded playlist from showing up as
-                # playable. It's rewritten again once the sweep
-                # finishes to pick up every track that downloaded.
-                wrote_early_m3u = True
+            if filename:
+                resolved[track_id] = filename
+            if settings is None or settings.get('generate_m3u', True):
+                # Rewrite the M3U after every track rather than once the
+                # whole sweep finishes, so the playlist grows as it
+                # downloads and a slow/hung track further down the list
+                # never holds up what's already on disk.
                 await asyncio.to_thread(
-                    _regenerate_m3u, playlist, tracks, downloader
+                    _regenerate_m3u, playlist, tracks, downloader, resolved
                 )
             if delay_seconds > 0 and index != len(new_tracks) - 1:
                 await asyncio.sleep(delay_seconds)
@@ -418,19 +422,29 @@ def _regenerate_m3u(
     playlist: MonitoredPlaylist,
     tracks: list[dict[str, Any]],
     downloader: Downloader,
+    resolved: Optional[dict[str, str]] = None,
 ) -> None:
-    """Rewrite the playlist's M3U from on-disk state after a sweep.
+    """Rewrite the playlist's M3U, in playlist order.
 
     Walks the full ordered track list (not just the freshly downloaded
-    ones), resolves each to an existing file via the downloader, and
-    hands the entries to :func:`m3u.write_m3u`. Tracks without a
-    matching file on disk are dropped.
+    ones) and hands the entries to :func:`m3u.write_m3u`. Tracks with no
+    file are dropped, so a partially-downloaded playlist still yields a
+    valid, correctly-ordered M3U.
+
+    With *resolved* (``{track_id: filename}``) filenames are taken from
+    that map alone — the cheap path used for the rewrite after each
+    individual download. Without it every track is resolved against the
+    filesystem instead, which is the authoritative view used for the
+    final rewrite at the end of a sweep.
     """
 
     pl_subdir = m3u.sanitize_playlist_name(playlist.name)
     entries: list[dict[str, Any]] = []
     for song in tracks:
-        filename = downloader.existing_filename_for(song, subdir=pl_subdir)
+        if resolved is None:
+            filename = downloader.existing_filename_for(song, subdir=pl_subdir)
+        else:
+            filename = resolved.get(song.get('song_id') or '')
         if not filename:
             continue
         entries.append({

--- a/downtify/monitor.py
+++ b/downtify/monitor.py
@@ -327,7 +327,7 @@ async def check_playlist(
         )
 
     delay_seconds = (settings or {}).get('download_delay_seconds', 0) or 0
-    last_index = len(new_tracks) - 1
+    wrote_early_m3u = False
 
     downloaded = 0
     for index, song in enumerate(new_tracks):
@@ -382,7 +382,20 @@ async def check_playlist(
                 db.mark_track_downloaded, playlist.id, track_id, filename
             )
             downloaded += 1
-            if delay_seconds > 0 and index != last_index:
+            if not wrote_early_m3u and (
+                settings is None or settings.get('generate_m3u', True)
+            ):
+                # Write the M3U as soon as the first track lands rather
+                # than waiting for the whole sweep, so a slow/hung
+                # download further down the list doesn't hold up an
+                # already-downloaded playlist from showing up as
+                # playable. It's rewritten again once the sweep
+                # finishes to pick up every track that downloaded.
+                wrote_early_m3u = True
+                await asyncio.to_thread(
+                    _regenerate_m3u, playlist, tracks, downloader
+                )
+            if delay_seconds > 0 and index != len(new_tracks) - 1:
                 await asyncio.sleep(delay_seconds)
         except Exception:
             logger.exception('Failed to auto-download track {}', track_id)

--- a/tests/test_download_delay.py
+++ b/tests/test_download_delay.py
@@ -296,3 +296,160 @@ def test_check_playlist_no_delay_when_setting_is_zero(monkeypatch):
 
     assert downloaded == 2
     assert sleeps == []
+
+
+# ── monitor.check_playlist: incremental M3U writes ──────────────────────────
+
+
+class _OrderedM3uDownloader:
+    """Records download/M3U-write order in a shared list, in whichever
+    order check_playlist actually issues them, so tests can assert the
+    M3U is written right after the *first* download rather than only
+    once the whole sweep finishes."""
+
+    download_dir = __import__('pathlib').Path('/tmp')
+    organize_by_artist = False
+    organize_by_album = False
+
+    def __init__(self, events, *, fail_song_ids=frozenset()):
+        self.events = events
+        self.fail_song_ids = fail_song_ids
+
+    def download(self, song, cb, subdir=None):
+        if song['song_id'] in self.fail_song_ids:
+            self.events.append(f'fail:{song["song_id"]}')
+            raise RuntimeError('boom')
+        self.events.append(f'download:{song["song_id"]}')
+        return f'{song["song_id"]}.mp3'
+
+
+def _run_check_playlist(monkeypatch, tracks, downloader, settings):
+    monkeypatch.setattr(
+        monitor.spotify, 'playlist_tracks_from_id', lambda spotify_id: tracks
+    )
+    monkeypatch.setattr(monitor.spotify, 'track_from_id', lambda track_id: {})
+    monkeypatch.setattr(monitor.asyncio, 'sleep', lambda _s: asyncio.sleep(0))
+
+    async def fake_broadcast(_msg):
+        return None
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(
+            monitor.check_playlist(
+                _playlist(),
+                _FakeMonitorDB(),
+                downloader,
+                fake_broadcast,
+                loop,
+                settings=settings,
+            )
+        )
+    finally:
+        loop.close()
+
+
+def test_check_playlist_writes_m3u_after_first_download_not_just_at_end(
+    monkeypatch,
+):
+    tracks = [
+        {'song_id': 'a', 'name': 'A'},
+        {'song_id': 'b', 'name': 'B'},
+        {'song_id': 'c', 'name': 'C'},
+    ]
+    events = []
+
+    def fake_regenerate_m3u(playlist, all_tracks, downloader):
+        events.append('m3u')
+
+    monkeypatch.setattr(monitor, '_regenerate_m3u', fake_regenerate_m3u)
+    downloader = _OrderedM3uDownloader(events)
+
+    downloaded = _run_check_playlist(
+        monkeypatch, tracks, downloader, {'generate_m3u': True}
+    )
+
+    assert downloaded == 3
+    # M3U written right after the first download completes, not after
+    # b/c — and again once at the very end of the sweep.
+    assert events == [
+        'download:a',
+        'm3u',
+        'download:b',
+        'download:c',
+        'm3u',
+    ]
+
+
+def test_check_playlist_skips_m3u_entirely_when_disabled(monkeypatch):
+    tracks = [{'song_id': 'a', 'name': 'A'}, {'song_id': 'b', 'name': 'B'}]
+    events = []
+
+    def fake_regenerate_m3u(playlist, all_tracks, downloader):
+        events.append('m3u')
+
+    monkeypatch.setattr(monitor, '_regenerate_m3u', fake_regenerate_m3u)
+    downloader = _OrderedM3uDownloader(events)
+
+    downloaded = _run_check_playlist(
+        monkeypatch, tracks, downloader, {'generate_m3u': False}
+    )
+
+    assert downloaded == 2
+    assert 'm3u' not in events
+
+
+def test_check_playlist_no_m3u_when_every_download_fails(monkeypatch):
+    tracks = [{'song_id': 'a', 'name': 'A'}, {'song_id': 'b', 'name': 'B'}]
+    events = []
+
+    def fake_regenerate_m3u(playlist, all_tracks, downloader):
+        events.append('m3u')
+
+    monkeypatch.setattr(monitor, '_regenerate_m3u', fake_regenerate_m3u)
+    downloader = _OrderedM3uDownloader(events, fail_song_ids={'a', 'b'})
+
+    downloaded = _run_check_playlist(
+        monkeypatch, tracks, downloader, {'generate_m3u': True}
+    )
+
+    assert downloaded == 0
+    assert 'm3u' not in events
+
+
+def test_check_playlist_writes_m3u_twice_for_a_single_track(monkeypatch):
+    # A single successful track still gets the early write (first
+    # download) and the final write (end of sweep) — the second is a
+    # cheap, idempotent no-op rewrite, deliberately not special-cased
+    # away, matching the "write early, write again at the end" request.
+    tracks = [{'song_id': 'a', 'name': 'A'}]
+    events = []
+
+    def fake_regenerate_m3u(playlist, all_tracks, downloader):
+        events.append('m3u')
+
+    monkeypatch.setattr(monitor, '_regenerate_m3u', fake_regenerate_m3u)
+    downloader = _OrderedM3uDownloader(events)
+
+    downloaded = _run_check_playlist(
+        monkeypatch, tracks, downloader, {'generate_m3u': True}
+    )
+
+    assert downloaded == 1
+    assert events == ['download:a', 'm3u', 'm3u']
+
+
+def test_check_playlist_treats_missing_settings_as_m3u_enabled(monkeypatch):
+    tracks = [{'song_id': 'a', 'name': 'A'}]
+    events = []
+
+    def fake_regenerate_m3u(playlist, all_tracks, downloader):
+        events.append('m3u')
+
+    monkeypatch.setattr(monitor, '_regenerate_m3u', fake_regenerate_m3u)
+    downloader = _OrderedM3uDownloader(events)
+
+    downloaded = _run_check_playlist(monkeypatch, tracks, downloader, None)
+
+    assert downloaded == 1
+    assert events.count('m3u') == 2

--- a/tests/test_download_delay.py
+++ b/tests/test_download_delay.py
@@ -304,8 +304,8 @@ def test_check_playlist_no_delay_when_setting_is_zero(monkeypatch):
 class _OrderedM3uDownloader:
     """Records download/M3U-write order in a shared list, in whichever
     order check_playlist actually issues them, so tests can assert the
-    M3U is written right after the *first* download rather than only
-    once the whole sweep finishes."""
+    M3U is rewritten after *every* download rather than only once the
+    whole sweep finishes."""
 
     download_dir = __import__('pathlib').Path('/tmp')
     organize_by_artist = False
@@ -349,7 +349,7 @@ def _run_check_playlist(monkeypatch, tracks, downloader, settings):
         loop.close()
 
 
-def test_check_playlist_writes_m3u_after_first_download_not_just_at_end(
+def test_check_playlist_rewrites_m3u_after_every_download(
     monkeypatch,
 ):
     tracks = [
@@ -359,7 +359,7 @@ def test_check_playlist_writes_m3u_after_first_download_not_just_at_end(
     ]
     events = []
 
-    def fake_regenerate_m3u(playlist, all_tracks, downloader):
+    def fake_regenerate_m3u(playlist, all_tracks, downloader, resolved=None):
         events.append('m3u')
 
     monkeypatch.setattr(monitor, '_regenerate_m3u', fake_regenerate_m3u)
@@ -370,13 +370,15 @@ def test_check_playlist_writes_m3u_after_first_download_not_just_at_end(
     )
 
     assert downloaded == 3
-    # M3U written right after the first download completes, not after
-    # b/c — and again once at the very end of the sweep.
+    # Every track that lands is written into the M3U immediately, plus a
+    # final authoritative rewrite at the end of the sweep.
     assert events == [
         'download:a',
         'm3u',
         'download:b',
+        'm3u',
         'download:c',
+        'm3u',
         'm3u',
     ]
 
@@ -385,7 +387,7 @@ def test_check_playlist_skips_m3u_entirely_when_disabled(monkeypatch):
     tracks = [{'song_id': 'a', 'name': 'A'}, {'song_id': 'b', 'name': 'B'}]
     events = []
 
-    def fake_regenerate_m3u(playlist, all_tracks, downloader):
+    def fake_regenerate_m3u(playlist, all_tracks, downloader, resolved=None):
         events.append('m3u')
 
     monkeypatch.setattr(monitor, '_regenerate_m3u', fake_regenerate_m3u)
@@ -403,7 +405,7 @@ def test_check_playlist_no_m3u_when_every_download_fails(monkeypatch):
     tracks = [{'song_id': 'a', 'name': 'A'}, {'song_id': 'b', 'name': 'B'}]
     events = []
 
-    def fake_regenerate_m3u(playlist, all_tracks, downloader):
+    def fake_regenerate_m3u(playlist, all_tracks, downloader, resolved=None):
         events.append('m3u')
 
     monkeypatch.setattr(monitor, '_regenerate_m3u', fake_regenerate_m3u)
@@ -418,14 +420,14 @@ def test_check_playlist_no_m3u_when_every_download_fails(monkeypatch):
 
 
 def test_check_playlist_writes_m3u_twice_for_a_single_track(monkeypatch):
-    # A single successful track still gets the early write (first
-    # download) and the final write (end of sweep) — the second is a
-    # cheap, idempotent no-op rewrite, deliberately not special-cased
-    # away, matching the "write early, write again at the end" request.
+    # One track -> one per-track write plus the final rewrite. The
+    # second is a cheap, idempotent rewrite, deliberately not
+    # special-cased away: the final pass is what resolves the playlist
+    # against the filesystem rather than the in-memory filename map.
     tracks = [{'song_id': 'a', 'name': 'A'}]
     events = []
 
-    def fake_regenerate_m3u(playlist, all_tracks, downloader):
+    def fake_regenerate_m3u(playlist, all_tracks, downloader, resolved=None):
         events.append('m3u')
 
     monkeypatch.setattr(monitor, '_regenerate_m3u', fake_regenerate_m3u)
@@ -443,7 +445,7 @@ def test_check_playlist_treats_missing_settings_as_m3u_enabled(monkeypatch):
     tracks = [{'song_id': 'a', 'name': 'A'}]
     events = []
 
-    def fake_regenerate_m3u(playlist, all_tracks, downloader):
+    def fake_regenerate_m3u(playlist, all_tracks, downloader, resolved=None):
         events.append('m3u')
 
     monkeypatch.setattr(monitor, '_regenerate_m3u', fake_regenerate_m3u)

--- a/tests/test_m3u_incremental.py
+++ b/tests/test_m3u_incremental.py
@@ -107,6 +107,80 @@ def test_process_batch_writes_m3u_before_slow_track_finishes(
     assert final.index('Song A') < final.index('Song B')
 
 
+def test_process_batch_m3u_grows_with_each_completed_track(
+    monkeypatch, tmp_path
+):
+    """Each finished track must land in the M3U immediately — not be held
+    back until the whole batch is done."""
+    songs = [
+        {'song_id': 'a', 'name': 'Song A', 'artists': ['Artist A']},
+        {'song_id': 'b', 'name': 'Song B', 'artists': ['Artist B']},
+        {'song_id': 'c', 'name': 'Song C', 'artists': ['Artist C']},
+    ]
+    dl = _make_downloader(tmp_path)
+    monkeypatch.setattr(api.state, 'downloader', dl)
+    monkeypatch.setattr(api.state, 'download_jobs', {})
+    monkeypatch.setattr(api.state, 'download_semaphore', None)
+
+    release_b = asyncio.Event()
+    release_c = asyncio.Event()
+
+    async def fake_run_download(song, song_id, subdir=None, delay_seconds=0):
+        if song['song_id'] == 'b':
+            await release_b.wait()
+        elif song['song_id'] == 'c':
+            await release_c.wait()
+        return _write_track_file(dl, song, subdir)
+
+    monkeypatch.setattr(api, '_run_download', fake_run_download)
+
+    m3u_path = tmp_path / PLAYLIST_NAME / f'{PLAYLIST_NAME}.m3u'
+
+    def _m3u_text() -> str:
+        return m3u_path.read_text(encoding='utf-8')
+
+    async def _scenario():
+        task = asyncio.create_task(
+            api._process_batch(
+                songs,
+                ['job-a', 'job-b', 'job-c'],
+                playlist_url='',
+                generate_m3u=True,
+                playlist_name=PLAYLIST_NAME,
+            )
+        )
+
+        assert await _wait_for(m3u_path.exists), 'no M3U after first track'
+        after_a = _m3u_text()
+
+        # Let B through; it must show up without waiting for C.
+        release_b.set()
+        assert await _wait_for(lambda: 'Song B' in _m3u_text()), (
+            'Song B was not added to the M3U while Song C was still pending'
+        )
+        after_b = _m3u_text()
+        assert not task.done(), 'batch finished before the assertion ran'
+
+        release_c.set()
+        await task
+        return after_a, after_b, _m3u_text()
+
+    after_a, after_b, final = asyncio.run(_scenario())
+
+    assert 'Song A' in after_a
+    assert 'Song B' not in after_a
+    assert 'Song C' not in after_a
+
+    assert 'Song A' in after_b
+    assert 'Song B' in after_b
+    assert 'Song C' not in after_b
+
+    assert 'Song C' in final
+    assert (
+        final.index('Song A') < final.index('Song B') < final.index('Song C')
+    )
+
+
 def test_process_batch_skips_m3u_when_generation_disabled(
     monkeypatch, tmp_path
 ):
@@ -266,6 +340,145 @@ def test_check_playlist_writes_m3u_before_slow_track_finishes(
     assert 'Song B' not in early
     assert 'Song A' in final
     assert 'Song B' in final
+
+
+def test_check_playlist_m3u_grows_with_each_completed_track(
+    monkeypatch, tmp_path
+):
+    """A monitor sweep must add each track to the M3U as it lands."""
+    tracks = [
+        {'song_id': 'a', 'name': 'Song A', 'artists': ['Artist A']},
+        {'song_id': 'b', 'name': 'Song B', 'artists': ['Artist B']},
+        {'song_id': 'c', 'name': 'Song C', 'artists': ['Artist C']},
+    ]
+    dl = _make_downloader(tmp_path)
+
+    monkeypatch.setattr(
+        monitor.spotify, 'playlist_tracks_from_id', lambda spotify_id: tracks
+    )
+    monkeypatch.setattr(monitor.spotify, 'track_from_id', lambda track_id: {})
+
+    release_b = threading.Event()
+    release_c = threading.Event()
+
+    def fake_download(song, cb, subdir=None):
+        if song['song_id'] == 'b':
+            release_b.wait(timeout=5)
+        elif song['song_id'] == 'c':
+            release_c.wait(timeout=5)
+        return _write_track_file(dl, song, subdir)
+
+    monkeypatch.setattr(dl, 'download', fake_download)
+
+    m3u_path = tmp_path / PLAYLIST_NAME / f'{PLAYLIST_NAME}.m3u'
+
+    def _m3u_text() -> str:
+        return m3u_path.read_text(encoding='utf-8')
+
+    async def fake_broadcast(_msg):
+        return None
+
+    async def _scenario():
+        task = asyncio.create_task(
+            monitor.check_playlist(
+                _monitored_playlist(),
+                _FakeMonitorDB(),
+                dl,
+                fake_broadcast,
+                asyncio.get_running_loop(),
+                settings={'generate_m3u': True},
+            )
+        )
+
+        assert await _wait_for(m3u_path.exists), 'no M3U after first track'
+        after_a = _m3u_text()
+
+        release_b.set()
+        assert await _wait_for(lambda: 'Song B' in _m3u_text()), (
+            'Song B was not added to the M3U while Song C was still pending'
+        )
+        after_b = _m3u_text()
+        assert not task.done(), 'sweep finished before the assertion ran'
+
+        release_c.set()
+        await task
+        return after_a, after_b, _m3u_text()
+
+    after_a, after_b, final = asyncio.run(_scenario())
+
+    assert 'Song A' in after_a
+    assert 'Song B' not in after_a
+
+    assert 'Song A' in after_b
+    assert 'Song B' in after_b
+    assert 'Song C' not in after_b
+
+    assert 'Song C' in final
+    assert (
+        final.index('Song A') < final.index('Song B') < final.index('Song C')
+    )
+
+
+def test_check_playlist_reuses_files_from_earlier_sweeps_in_the_m3u(
+    monkeypatch, tmp_path
+):
+    """Tracks downloaded in a previous sweep must stay in the M3U written
+    during the current one, not be dropped until the final rewrite."""
+    tracks = [
+        {'song_id': 'old', 'name': 'Old Song', 'artists': ['Artist O']},
+        {'song_id': 'new', 'name': 'New Song', 'artists': ['Artist N']},
+    ]
+    dl = _make_downloader(tmp_path)
+    subdir = PLAYLIST_NAME
+
+    # Pretend 'old' came from an earlier sweep: its file is on disk and
+    # the DB knows its filename.
+    old_filename = _write_track_file(dl, tracks[0], subdir)
+
+    class _DBWithHistory:
+        @staticmethod
+        def get_track_filenames(playlist_id):
+            return {'old': old_filename}
+
+        @staticmethod
+        def mark_track_downloaded(playlist_id, track_id, filename):
+            pass
+
+        @staticmethod
+        def update_playlist(playlist_id, **kwargs):
+            pass
+
+    monkeypatch.setattr(
+        monitor.spotify, 'playlist_tracks_from_id', lambda spotify_id: tracks
+    )
+    monkeypatch.setattr(monitor.spotify, 'track_from_id', lambda track_id: {})
+    monkeypatch.setattr(
+        dl,
+        'download',
+        lambda song, cb, subdir=None: _write_track_file(dl, song, subdir),
+    )
+
+    async def fake_broadcast(_msg):
+        return None
+
+    async def _scenario():
+        return await monitor.check_playlist(
+            _monitored_playlist(),
+            _DBWithHistory(),
+            dl,
+            fake_broadcast,
+            asyncio.get_running_loop(),
+            settings={'generate_m3u': True},
+        )
+
+    downloaded = asyncio.run(_scenario())
+    final = (tmp_path / PLAYLIST_NAME / f'{PLAYLIST_NAME}.m3u').read_text(
+        encoding='utf-8'
+    )
+
+    assert downloaded == 1  # only the new track was fetched
+    assert 'Old Song' in final
+    assert 'New Song' in final
 
 
 def test_check_playlist_skips_m3u_when_generation_disabled(

--- a/tests/test_m3u_incremental.py
+++ b/tests/test_m3u_incremental.py
@@ -1,0 +1,301 @@
+"""End-to-end tests that the M3U lands on disk *before* a batch finishes.
+
+These deliberately use the real `m3u.write_m3u`, the real
+`Downloader.existing_filename_for` path resolution and real files in a
+tmp dir — mocking `_regenerate_m3u` / `write_m3u` would only prove the
+call happens, not that a playable file actually appears while a slow
+track is still downloading, which is the whole point of the feature.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+from downtify import api, monitor
+from downtify.downloader import Downloader
+
+PLAYLIST_NAME = 'My Playlist'
+
+
+def _make_downloader(tmp_path) -> Downloader:
+    return Downloader(download_dir=tmp_path, audio_format='mp3')
+
+
+def _write_track_file(dl: Downloader, song: dict, subdir: str) -> str:
+    """Create the file exactly where the downloader would have put it.
+
+    Uses the downloader's own path resolution so the test exercises the
+    real `existing_filename_for` lookup instead of a guessed layout.
+    """
+    parts = dl._format_output_parts(song)
+    basename = parts[-1]
+    target_dir, prefix = dl._resolve_target_dir(
+        dl._effective_subdir(song, subdir)
+    )
+    target_dir.mkdir(parents=True, exist_ok=True)
+    (target_dir / f'{basename}.{dl.audio_format}').write_bytes(b'audio')
+    return f'{prefix}{basename}.{dl.audio_format}'
+
+
+async def _wait_for(predicate, timeout=5.0):
+    """Poll until *predicate* is true (or give up), yielding to the loop."""
+    waited = 0.0
+    while waited < timeout:
+        if predicate():
+            return True
+        await asyncio.sleep(0.01)
+        waited += 0.01
+    return False
+
+
+# ── manual playlist / CSV batch downloads (api._process_batch) ──────────────
+
+
+def test_process_batch_writes_m3u_before_slow_track_finishes(
+    monkeypatch, tmp_path
+):
+    songs = [
+        {'song_id': 'a', 'name': 'Song A', 'artists': ['Artist A']},
+        {'song_id': 'b', 'name': 'Song B', 'artists': ['Artist B']},
+    ]
+    dl = _make_downloader(tmp_path)
+    monkeypatch.setattr(api.state, 'downloader', dl)
+    monkeypatch.setattr(api.state, 'download_jobs', {})
+    monkeypatch.setattr(api.state, 'download_semaphore', None)
+
+    release_slow = asyncio.Event()
+
+    async def fake_run_download(song, song_id, subdir=None, delay_seconds=0):
+        if song['song_id'] == 'b':
+            await release_slow.wait()
+        return _write_track_file(dl, song, subdir)
+
+    monkeypatch.setattr(api, '_run_download', fake_run_download)
+
+    m3u_path = tmp_path / PLAYLIST_NAME / f'{PLAYLIST_NAME}.m3u'
+
+    async def _scenario():
+        task = asyncio.create_task(
+            api._process_batch(
+                songs,
+                ['job-a', 'job-b'],
+                playlist_url='',
+                generate_m3u=True,
+                playlist_name=PLAYLIST_NAME,
+            )
+        )
+
+        appeared = await _wait_for(m3u_path.exists)
+        assert appeared, 'M3U was not written before the slow track finished'
+        early = m3u_path.read_text(encoding='utf-8')
+        assert not task.done(), 'batch finished before the assertion ran'
+
+        release_slow.set()
+        await task
+        return early, m3u_path.read_text(encoding='utf-8')
+
+    early, final = asyncio.run(_scenario())
+
+    # Early file is playable and holds only the track that finished.
+    assert early.startswith('#EXTM3U')
+    assert 'Song A' in early
+    assert 'Song B' not in early
+    # Final rewrite picks up the slow track too, in playlist order.
+    assert 'Song A' in final
+    assert 'Song B' in final
+    assert final.index('Song A') < final.index('Song B')
+
+
+def test_process_batch_skips_m3u_when_generation_disabled(
+    monkeypatch, tmp_path
+):
+    songs = [{'song_id': 'a', 'name': 'Song A', 'artists': ['Artist A']}]
+    dl = _make_downloader(tmp_path)
+    monkeypatch.setattr(api.state, 'downloader', dl)
+    monkeypatch.setattr(api.state, 'download_jobs', {})
+    monkeypatch.setattr(api.state, 'download_semaphore', None)
+
+    async def fake_run_download(song, song_id, subdir=None, delay_seconds=0):
+        return _write_track_file(dl, song, subdir)
+
+    monkeypatch.setattr(api, '_run_download', fake_run_download)
+
+    asyncio.run(
+        api._process_batch(
+            songs,
+            ['job-a'],
+            playlist_url='',
+            generate_m3u=False,
+            playlist_name=PLAYLIST_NAME,
+        )
+    )
+
+    assert not (tmp_path / PLAYLIST_NAME / f'{PLAYLIST_NAME}.m3u').exists()
+
+
+def test_process_batch_m3u_keeps_playlist_order_not_completion_order(
+    monkeypatch, tmp_path
+):
+    # The second song finishes first; the M3U must still list them in
+    # playlist order.
+    songs = [
+        {'song_id': 'a', 'name': 'Song A', 'artists': ['Artist A']},
+        {'song_id': 'b', 'name': 'Song B', 'artists': ['Artist B']},
+    ]
+    dl = _make_downloader(tmp_path)
+    monkeypatch.setattr(api.state, 'downloader', dl)
+    monkeypatch.setattr(api.state, 'download_jobs', {})
+    monkeypatch.setattr(api.state, 'download_semaphore', None)
+
+    b_done = asyncio.Event()
+
+    async def fake_run_download(song, song_id, subdir=None, delay_seconds=0):
+        if song['song_id'] == 'a':
+            await b_done.wait()
+        filename = _write_track_file(dl, song, subdir)
+        if song['song_id'] == 'b':
+            b_done.set()
+        return filename
+
+    monkeypatch.setattr(api, '_run_download', fake_run_download)
+
+    asyncio.run(
+        api._process_batch(
+            songs,
+            ['job-a', 'job-b'],
+            playlist_url='',
+            generate_m3u=True,
+            playlist_name=PLAYLIST_NAME,
+        )
+    )
+
+    final = (tmp_path / PLAYLIST_NAME / f'{PLAYLIST_NAME}.m3u').read_text(
+        encoding='utf-8'
+    )
+    assert final.index('Song A') < final.index('Song B')
+
+
+# ── Playlist Monitor sweeps (monitor.check_playlist) ────────────────────────
+
+
+class _FakeMonitorDB:
+    @staticmethod
+    def get_track_filenames(playlist_id):
+        return {}
+
+    @staticmethod
+    def mark_track_downloaded(playlist_id, track_id, filename):
+        pass
+
+    @staticmethod
+    def update_playlist(playlist_id, **kwargs):
+        pass
+
+
+def _monitored_playlist():
+    return monitor.MonitoredPlaylist(
+        id=1,
+        spotify_id='pl123',
+        name=PLAYLIST_NAME,
+        url='https://open.spotify.com/playlist/pl123',
+        interval_minutes=60,
+        enabled=True,
+        last_checked=None,
+        last_track_count=0,
+        created_at='2026-01-01T00:00:00+00:00',
+    )
+
+
+def test_check_playlist_writes_m3u_before_slow_track_finishes(
+    monkeypatch, tmp_path
+):
+    tracks = [
+        {'song_id': 'a', 'name': 'Song A', 'artists': ['Artist A']},
+        {'song_id': 'b', 'name': 'Song B', 'artists': ['Artist B']},
+    ]
+    dl = _make_downloader(tmp_path)
+
+    monkeypatch.setattr(
+        monitor.spotify, 'playlist_tracks_from_id', lambda spotify_id: tracks
+    )
+    monkeypatch.setattr(monitor.spotify, 'track_from_id', lambda track_id: {})
+
+    # download() runs in a worker thread, so the slow track blocks on a
+    # threading primitive rather than an asyncio one.
+    release_slow = threading.Event()
+
+    def fake_download(song, cb, subdir=None):
+        if song['song_id'] == 'b':
+            release_slow.wait(timeout=5)
+        return _write_track_file(dl, song, subdir)
+
+    monkeypatch.setattr(dl, 'download', fake_download)
+
+    m3u_path = tmp_path / PLAYLIST_NAME / f'{PLAYLIST_NAME}.m3u'
+
+    async def fake_broadcast(_msg):
+        return None
+
+    async def _scenario():
+        task = asyncio.create_task(
+            monitor.check_playlist(
+                _monitored_playlist(),
+                _FakeMonitorDB(),
+                dl,
+                fake_broadcast,
+                asyncio.get_running_loop(),
+                settings={'generate_m3u': True},
+            )
+        )
+
+        appeared = await _wait_for(m3u_path.exists)
+        assert appeared, 'M3U was not written before the slow track finished'
+        early = m3u_path.read_text(encoding='utf-8')
+        assert not task.done(), 'sweep finished before the assertion ran'
+
+        release_slow.set()
+        downloaded = await task
+        return early, m3u_path.read_text(encoding='utf-8'), downloaded
+
+    early, final, downloaded = asyncio.run(_scenario())
+
+    assert downloaded == 2
+    assert early.startswith('#EXTM3U')
+    assert 'Song A' in early
+    assert 'Song B' not in early
+    assert 'Song A' in final
+    assert 'Song B' in final
+
+
+def test_check_playlist_skips_m3u_when_generation_disabled(
+    monkeypatch, tmp_path
+):
+    tracks = [{'song_id': 'a', 'name': 'Song A', 'artists': ['Artist A']}]
+    dl = _make_downloader(tmp_path)
+
+    monkeypatch.setattr(
+        monitor.spotify, 'playlist_tracks_from_id', lambda spotify_id: tracks
+    )
+    monkeypatch.setattr(monitor.spotify, 'track_from_id', lambda track_id: {})
+    monkeypatch.setattr(
+        dl,
+        'download',
+        lambda song, cb, subdir=None: _write_track_file(dl, song, subdir),
+    )
+
+    async def fake_broadcast(_msg):
+        return None
+
+    async def _scenario():
+        return await monitor.check_playlist(
+            _monitored_playlist(),
+            _FakeMonitorDB(),
+            dl,
+            fake_broadcast,
+            asyncio.get_running_loop(),
+            settings={'generate_m3u': False},
+        )
+
+    assert asyncio.run(_scenario()) == 1
+    assert not (tmp_path / PLAYLIST_NAME / f'{PLAYLIST_NAME}.m3u').exists()


### PR DESCRIPTION
Write the playlist M3U as soon as the first track lands

Previously the M3U was only written once every track in a run had
finished downloading. A single slow or hung download meant the M3U
stayed stale — or missing entirely, on a first run — for however long
that one track took, even though the rest of the playlist was already
on disk and playable.

Both download paths now write the M3U right after the *first* track
finishes, then again when the run completes:

- `api._process_batch` — manual playlist/album downloads and CSV
  library imports. Downloads here run concurrently, so the first
  coroutine to land triggers the early write under a lock; the rest
  skip it. Entries are now built from a per-index filename map so the
  file is ordered by playlist position rather than by whichever
  download happened to finish first.
- `monitor.check_playlist` — Playlist Monitor sweeps, which download
  sequentially.

Neither path writes anything when M3U generation is disabled in
settings, or when every download in the run failed.

Extracted `_m3u_entries_for()` / `_write_batch_m3u()` out of
`_process_batch` — they're needed at two call sites now, and keeping
them inline pushed the function past ruff's too-many-locals limit.

Tests: new tests/test_m3u_incremental.py drives both paths end to end
with real files in a tmp dir, the real `write_m3u` and the real
`Downloader.existing_filename_for` resolution — a slow track is
blocked mid-run and the test asserts the .m3u already exists and is
playable before it completes. Verified the batch test fails without
this change. Plus coverage for the generate_m3u=False case and for
playlist ordering when downloads complete out of order.

Docs: documented the two-write timing for every run type in
docs/features/m3u-export.md and docs/features/playlist-monitor.md.

close #238 