### PR TITLE
feat: Add {tracknumber} filename template token

### DIFF
--- a/docs/features/download-settings.md
+++ b/docs/features/download-settings.md
@@ -44,6 +44,16 @@ Available tokens:
 | `{title}` | Track title |
 | `{artists}` | Comma-separated artist names |
 | `{album}` | Album name |
+| `{tracknumber}` | Track's position on its album, zero-padded to 2 digits (e.g. `01`, `12`). Empty when the source has no track number (e.g. a free-text/YouTube search result). |
+
+The template can also include `/` to build subfolders. For example, to lay out a library as `Artist/Album/01 - Title.mp3`:
+
+```
+{artists}/{album}/{tracknumber} - {title}
+```
+
+!!! note
+    This is independent of the **Organize by artist** / **Organize by album** toggles below — those route playlist/album downloads into shared per-artist or per-album folders across your whole library. `{tracknumber}` just lets a template like the one above build that same layout manually, track by track, without turning those toggles on.
 
 ## Parallel downloads
 

--- a/downtify/downloader.py
+++ b/downtify/downloader.py
@@ -206,11 +206,19 @@ class Downloader:
     def _template_values(song: dict[str, Any]) -> dict[str, str]:
         artist_names = [_sanitize(a) for a in (song.get('artists') or [])]
         artists = ', '.join(a for a in artist_names if a) or 'Unknown Artist'
+        # Same normalization used for the embedded tag (see
+        # _album_track_index_for_tags): only a positive integer counts,
+        # anything else (missing, non-numeric, a free-text/YouTube search
+        # result with no Spotify track_number) renders as ''. Zero-padded
+        # to 2 digits so "{tracknumber} - {title}" sorts correctly in a
+        # file browser (2 < 10 lexicographically without padding).
+        track_number, _ = _album_track_index_for_tags(song)
         return {
             'title': _sanitize(song.get('name', 'Unknown')),
             'artists': artists,
             'artist': artists,
             'album': _sanitize(song.get('album_name', '')),
+            'tracknumber': f'{track_number:02d}' if track_number else '',
         }
 
     def _format_output_parts(self, song: dict[str, Any]) -> list[str]:

--- a/frontend/src/i18n/locales/el.js
+++ b/frontend/src/i18n/locales/el.js
@@ -172,7 +172,7 @@ export default {
     outputTemplate: 'Μορφή ονόματος αρχείου',
     outputTemplateReset: 'Επαναφορά',
     outputTemplateHint:
-      'Χρησιμοποιήστε / για υποφακέλους. Tokens: {artists}, {artist}, {title}, {album}, {output-ext}',
+      'Χρησιμοποιήστε / για υποφακέλους. Tokens: {artists}, {artist}, {title}, {album}, {tracknumber}, {output-ext}',
     searchSection: 'Αναζήτηση',
     searchAlbums: 'Εμφάνιση άλμπουμ στα αποτελέσματα αναζήτησης',
     searchAlbumsHint:

--- a/frontend/src/i18n/locales/en.js
+++ b/frontend/src/i18n/locales/en.js
@@ -167,7 +167,7 @@ export default {
     outputTemplate: 'Filename format',
     outputTemplateReset: 'Reset',
     outputTemplateHint:
-      'Use / to create subfolders. Tokens: {artists}, {artist}, {title}, {album}, {output-ext}',
+      'Use / to create subfolders. Tokens: {artists}, {artist}, {title}, {album}, {tracknumber}, {output-ext}',
     searchSection: 'Search',
     searchAlbums: 'Show albums in search results',
     searchAlbumsHint:

--- a/frontend/src/i18n/locales/es.js
+++ b/frontend/src/i18n/locales/es.js
@@ -171,7 +171,7 @@ export default {
     outputTemplate: 'Formato del nombre',
     outputTemplateReset: 'Restaurar',
     outputTemplateHint:
-      'Usa / para crear subcarpetas. Tokens: {artists}, {artist}, {title}, {album}, {output-ext}',
+      'Usa / para crear subcarpetas. Tokens: {artists}, {artist}, {title}, {album}, {tracknumber}, {output-ext}',
     searchSection: 'Búsqueda',
     searchAlbums: 'Mostrar álbumes en los resultados de búsqueda',
     searchAlbumsHint:

--- a/frontend/src/i18n/locales/hu.js
+++ b/frontend/src/i18n/locales/hu.js
@@ -172,7 +172,7 @@ export default {
     outputTemplate: 'Fájlnév formátuma',
     outputTemplateReset: 'Újra',
     outputTemplateHint:
-      'A / használatával hozzon létre almappákat. Tokenek: {artists}, {artist}, {title}, {album}, {output-ext}',
+      'A / használatával hozzon létre almappákat. Tokenek: {artists}, {artist}, {title}, {album}, {tracknumber}, {output-ext}',
     searchSection: 'Keresés',
     searchAlbums: 'Albumok megjelenítése a keresési eredményekben',
     searchAlbumsHint:

--- a/frontend/src/i18n/locales/pt-BR.js
+++ b/frontend/src/i18n/locales/pt-BR.js
@@ -170,7 +170,7 @@ export default {
     outputTemplate: 'Formato do nome',
     outputTemplateReset: 'Restaurar',
     outputTemplateHint:
-      'Use / para criar subpastas. Tokens: {artists}, {artist}, {title}, {album}, {output-ext}',
+      'Use / para criar subpastas. Tokens: {artists}, {artist}, {title}, {album}, {tracknumber}, {output-ext}',
     searchSection: 'Busca',
     searchAlbums: 'Mostrar álbuns nos resultados de busca',
     searchAlbumsHint:

--- a/frontend/src/i18n/locales/tr.js
+++ b/frontend/src/i18n/locales/tr.js
@@ -168,7 +168,7 @@ export default {
     outputTemplate: 'Dosya adı formatı',
     outputTemplateReset: 'Varsayılana dön',
     outputTemplateHint:
-      'Alt klasörler oluşturmak için "/" kullanılabilir. Değişkenler: {artists}, {artist}, {title}, {album}, {output-ext}',
+      'Alt klasörler oluşturmak için "/" kullanılabilir. Değişkenler: {artists}, {artist}, {title}, {album}, {tracknumber}, {output-ext}',
     playlistsSection: 'Çalma Listeleri',
     generateM3u: 'Çalma listeleri için M3U dosyaları oluştur',
     generateM3uHint:

--- a/tests/test_downloader_extended.py
+++ b/tests/test_downloader_extended.py
@@ -160,6 +160,74 @@ def test_format_basename_bad_template_falls_back(tmp_path):
     assert 'Song' in result
 
 
+# ── {tracknumber} template token ────────────────────────────────────────────
+
+
+def test_format_basename_tracknumber_zero_padded(tmp_path):
+    d = _make(tmp_path, output_template='{tracknumber} - {title}')
+    result = d._format_basename({
+        'name': 'Song',
+        'artists': ['A'],
+        'track_number': 7,
+    })
+    assert result == '07 - Song'
+
+
+def test_format_basename_tracknumber_not_padded_past_two_digits(tmp_path):
+    d = _make(tmp_path, output_template='{tracknumber} - {title}')
+    result = d._format_basename({
+        'name': 'Song',
+        'artists': ['A'],
+        'track_number': 123,
+    })
+    assert result == '123 - Song'
+
+
+def test_format_basename_tracknumber_missing_is_empty(tmp_path):
+    d = _make(tmp_path, output_template='{tracknumber} - {title}')
+    result = d._format_basename({'name': 'Song', 'artists': ['A']})
+    assert result == '- Song'
+
+
+def test_format_basename_tracknumber_non_numeric_is_empty(tmp_path):
+    d = _make(tmp_path, output_template='{tracknumber} - {title}')
+    result = d._format_basename({
+        'name': 'Song',
+        'artists': ['A'],
+        'track_number': 'not-a-number',
+    })
+    assert result == '- Song'
+
+
+def test_format_basename_tracknumber_zero_is_empty(tmp_path):
+    # track_number 0 isn't a valid position (matches the tag-embedding
+    # normalization in _album_track_index_for_tags).
+    d = _make(tmp_path, output_template='{tracknumber} - {title}')
+    result = d._format_basename({
+        'name': 'Song',
+        'artists': ['A'],
+        'track_number': 0,
+    })
+    assert result == '- Song'
+
+
+def test_format_basename_supports_full_artist_album_tracknumber_layout(
+    tmp_path,
+):
+    # The exact layout requested alongside this token: Artist/Album/NN -
+    # Title.
+    d = _make(
+        tmp_path, output_template='{artists}/{album}/{tracknumber} - {title}'
+    )
+    result = d._format_basename({
+        'name': 'Song',
+        'artists': ['The Night Owls'],
+        'album_name': 'First Light',
+        'track_number': 3,
+    })
+    assert result == 'The Night Owls/First Light/03 - Song'
+
+
 # ── _artist_subdir ────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Requested by a user who organizes their library as Artist/Album/NN - Title and had no way to build that layout since the filename template had no access to the track's position on its album.

downtify/downloader.py: Downloader._template_values() now exposes 'tracknumber', reusing the existing _album_track_index_for_tags() normalization (already used for the embedded TRCK/trkn/tracknumber tag) so the token and the tag agree on what counts as a valid track number. Zero-padded to 2 digits (01, 02, ..., not padded past that) so a template like "{tracknumber} - {title}" sorts correctly in a file browser - unpadded, "10" would sort before "2". Renders as an empty string when the source has no track number (free-text/YouTube search results, mainly), same fallback style already used for {album}.

Example, with output set to
"{artists}/{album}/{tracknumber} - {title}":

  The Night Owls/First Light/01 - Intro.mp3
  The Night Owls/First Light/02 - Do I Still Recall.mp3
  The Night Owls/First Light/12 - Track Twelve.mp3

Tests: 6 new cases in tests/test_downloader_extended.py covering padding, no padding past 2 digits, missing/non-numeric/zero track_number (all render as empty, matching the tag-embedding fallback), and the full Artist/Album/NN - Title layout from the request. Verified they fail without the change.

Docs: added the token to the table and an example in docs/features/download-settings.md, plus the Settings UI hint translated across the 6 locales that already carry that string (fr.js already lacked it pre-existing this change and falls back to English, unrelated to this token).

close #251