### PR TITLE
feat: Add a built-in Docker HEALTHCHECK, toggleable via DOWNTIFY_HEAL…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHON_COLORS=0 \
     DOWNTIFY_LOG_LEVEL=info \
     DOWNTIFY_PORT=8000 \
+    DOWNTIFY_HEALTHCHECK=1 \
     UID=1000 \
     GID=1000 \
     UMASK=022
@@ -61,12 +62,12 @@ RUN apk add --no-cache \
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 
-COPY main.py entrypoint.sh ./
+COPY main.py entrypoint.sh healthcheck.sh ./
 COPY downtify ./downtify
 COPY --from=frontend-builder /frontend/dist ./frontend/dist
 
-RUN sed -i 's/\r$//g' entrypoint.sh && \
-    chmod +x entrypoint.sh
+RUN sed -i 's/\r$//g' entrypoint.sh healthcheck.sh && \
+    chmod +x entrypoint.sh healthcheck.sh
 
 ENV PATH="/home/downtify/.local/bin:${PATH}"
 
@@ -74,5 +75,8 @@ VOLUME /downloads
 VOLUME /data
 
 EXPOSE ${DOWNTIFY_PORT}
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD ./healthcheck.sh
 
 ENTRYPOINT ["/sbin/tini", "-g", "--", "./entrypoint.sh"]

--- a/docs/getting-started/environment-variables.md
+++ b/docs/getting-started/environment-variables.md
@@ -27,6 +27,19 @@ environment:
   - DOWNTIFY_MONITOR_SYNC_TIME=03:00
 ```
 
+## Health check
+
+The image has a built-in [Docker `HEALTHCHECK`](https://docs.docker.com/reference/dockerfile/#healthcheck) — no custom `--health-cmd` needed. It polls `GET /api/health` on the container's own port every 30 seconds (5 second timeout, 20 second start-up grace period, 3 retries before the container is marked unhealthy). `docker ps` and `docker inspect` show the result, and tools like Compose's `condition: service_healthy` or Watchtower can act on it.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DOWNTIFY_HEALTHCHECK` | `1` | Set to `0` to disable the built-in check — it then always reports healthy without contacting the server. Use this if an external/orchestrator-level check (e.g. a Kubernetes liveness probe) should be the only one deciding container health. |
+
+```yaml
+environment:
+  - DOWNTIFY_HEALTHCHECK=0
+```
+
 ## Anti-bot / YouTube
 
 YouTube periodically challenges automated downloaders. These variables give you escape hatches when the defaults stop working.

--- a/downtify/api.py
+++ b/downtify/api.py
@@ -5,6 +5,9 @@ The endpoints intentionally mirror the surface that the previous
 working without changes:
 
 * ``GET  /api/version``
+* ``GET  /api/health`` (liveness probe for the Docker ``HEALTHCHECK`` -
+  see ``healthcheck.sh``; always ``200`` once the server can answer
+  requests, regardless of downloader/monitor readiness)
 * ``GET  /api/songs/search``
 * ``GET  /api/artists/search``
 * ``GET  /api/artists/top_songs`` (an artist's "Top songs" shelf preview,
@@ -222,6 +225,19 @@ def _save_settings(path: Path, settings: dict[str, Any]) -> None:
 @router.get('/api/version')
 def get_version() -> str:
     return state.version
+
+
+@router.get('/api/health')
+def get_health() -> dict[str, Any]:
+    """Liveness probe: the process is up and FastAPI is serving requests.
+
+    Deliberately doesn't check the downloader/monitor DB — those are
+    only set up once ``main.py``'s startup hook finishes, so gating
+    health on them would report unhealthy during the brief, normal
+    window right after boot. Docker's ``HEALTHCHECK`` already has a
+    ``--start-period`` for that; this endpoint just needs to answer.
+    """
+    return {'status': 'ok', 'version': state.version}
 
 
 @router.get('/api/check_update')

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Probe for the Docker HEALTHCHECK instruction (see Dockerfile).
+#
+# Enabled by default. Set DOWNTIFY_HEALTHCHECK=0 to disable it — the
+# check then always reports healthy without touching the server, for
+# setups where an external/orchestrator-level check (e.g. a Kubernetes
+# liveness probe) should be the only one deciding container health.
+case "$(printf '%s' "${DOWNTIFY_HEALTHCHECK:-1}" | tr '[:upper:]' '[:lower:]')" in
+    0 | false | no | off) exit 0 ;;
+esac
+
+wget -q -O /dev/null "http://127.0.0.1:${DOWNTIFY_PORT:-8000}/api/health"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,27 @@
+"""Tests for GET /api/health, the Docker HEALTHCHECK liveness probe."""
+
+from __future__ import annotations
+
+from downtify import api
+from downtify.api import get_health
+
+
+def test_health_returns_ok_status():
+    result = get_health()
+    assert result['status'] == 'ok'
+
+
+def test_health_reports_current_version(monkeypatch):
+    monkeypatch.setattr(api.state, 'version', '9.9.9')
+    result = get_health()
+    assert result['version'] == '9.9.9'
+
+
+def test_health_does_not_require_downloader(monkeypatch):
+    # A liveness probe must answer during the brief startup window before
+    # main.py's startup hook has set up the downloader/monitor DB — it
+    # should never depend on state that isn't ready yet.
+    monkeypatch.setattr(api.state, 'downloader', None)
+    monkeypatch.setattr(api.state, 'monitor_db', None)
+    result = get_health()
+    assert result['status'] == 'ok'


### PR DESCRIPTION
…THCHECK

Replaces the need for a hand-rolled --health-cmd (per the request: "custom command can be used but is not always reliable") with a liveness check baked into the image.

- New GET /api/health endpoint (downtify/api.py): always 200 once FastAPI is serving requests. Deliberately doesn't check the downloader/monitor DB, which are only set up once main.py's startup hook finishes — gating health on them would report unhealthy during the normal window right after boot.
- healthcheck.sh: probes that endpoint with wget (already present via BusyBox on the python:3.13-alpine base — verified inside the actual image rather than assumed; no new package needed, unlike curl which the base image doesn't ship). Reads DOWNTIFY_HEALTHCHECK and exits 0 immediately without touching the network when it's "0" (or false/ no/off), for setups where an external/orchestrator-level check (e.g. Kubernetes) should be the only one deciding container health.
- Dockerfile: HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3, and DOWNTIFY_HEALTHCHECK=1 default.

Verified against a real build, not just the Dockerfile syntax: built the image, ran a container, and watched `docker inspect .State.Health` go starting -> healthy with a real 0-exit-code probe log entry. Separately confirmed DOWNTIFY_HEALTHCHECK=0 makes the script exit 0 immediately (both via manual `docker exec ./healthcheck.sh` and by booting a second container with the var set from the start, which reached "healthy" without the app ever being hit). Test containers/images/volumes cleaned up afterward.

Tests: tests/test_health.py covers the endpoint directly (ok status, reports state.version, doesn't require the downloader to be ready).

Docs: new "Health check" section in
docs/getting-started/environment-variables.md documenting the variable, defaults and an opt-out example.

close #258