### PR TITLE
feat: Let the Built-in Player play a single downloaded playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Downtify ships with a clean web player so you don't need a separate app to liste
 - **Repeat** modes: off → all → one
 - Volume slider with mute toggle (volume is remembered between sessions)
 - Side queue listing every track in your library, each one with its own thumbnail and the currently playing one highlighted
+- **Playing from** selector — play just one downloaded playlist instead of your whole library queued at once. See **[Built-in Player](https://henriquesebastiao.github.io/downtify/features/player/)** in the full docs.
 
 The player parses `Artist - Title.ext` filenames so the now-playing card shows artist and title nicely, and pulls the cover art directly from the audio file's embedded tags (the same artwork Downtify wrote at download time). Playback uses your browser's native HTML5 audio element — no extra dependencies, no extra processes.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -222,6 +222,22 @@ List all audio files in the downloads directory (recursive).
 
 ---
 
+### `GET /playlists`
+
+List downloaded playlists, derived from the `.m3u` files already on disk (see [M3U Export](features/m3u-export.md)). Used by the [Built-in Player](features/player.md#playing-a-single-playlist) to offer "play just this playlist" instead of the whole library.
+
+**Response:**
+
+```json
+[
+  { "name": "My Playlist", "files": ["My Playlist/Artist - Song.mp3"], "count": 1 }
+]
+```
+
+Sorted by name. A single track or an album downloaded without an M3U doesn't appear here.
+
+---
+
 ### `DELETE /delete`
 
 Delete a downloaded file.

--- a/docs/features/player.md
+++ b/docs/features/player.md
@@ -15,10 +15,17 @@ Downtify ships with a web player so you can listen to your downloaded music with
 - **Repeat modes** — off → repeat all → repeat one
 - **Volume slider** — with mute toggle; your volume level is saved between sessions
 - **Side queue** — all tracks in your library, each with its own thumbnail; the currently playing track is highlighted
+- **Playing from** — pick **All Songs** or one specific downloaded playlist, instead of always queuing your whole library
+
+## Playing a single playlist
+
+By default the player queues every downloaded track. Use the **Playing from** selector next to the page title to switch the queue to just one playlist. This picks up any playlist that has an [M3U file](m3u-export.md) — playlist and album downloads, [CSV imports](library-import.md), and [Playlist Monitor](playlist-monitor.md) all write one automatically, so this works retroactively on everything you've already downloaded. A single track or an album downloaded without an M3U (e.g. via the YouTube Music album flow) isn't a "playlist" and won't appear in the list — it's still part of **All Songs**.
+
+Switching playlists replaces the queue and stops whatever was playing; pick a track or hit play to start the new one. Reopening the player later resumes whichever queue (all songs or a specific playlist) was last loaded.
 
 ## How it works
 
-The player loads every audio file found recursively inside the downloads directory. Files are served directly from the container via the `/downloads` static mount.
+The player loads every audio file found recursively inside the downloads directory. Files are served directly from the container via the `/downloads` static mount. The playlist selector is built from the `.m3u` files already on disk — no separate playlist database.
 
 Filenames in the format `Artist - Title.ext` are parsed so the now-playing card can show artist and title cleanly. Cover art is fetched on demand from the `/cover` endpoint, which reads the embedded image tags from the file itself — the same artwork Downtify wrote at download time.
 

--- a/downtify/m3u.py
+++ b/downtify/m3u.py
@@ -91,6 +91,41 @@ def build_m3u_content(
     return '\n'.join(lines) + '\n', kept
 
 
+def read_m3u_tracks(m3u_path: Path, download_dir: Path) -> list[str]:
+    """Return the tracks listed in *m3u_path*, as paths relative to
+    *download_dir* (the same shape ``/list`` returns), in file order.
+
+    Inverts the relative-path scheme :func:`build_m3u_content` writes:
+    each non-comment line is relative to the M3U's own directory, not to
+    *download_dir*. Lines that don't resolve to an existing file under
+    *download_dir* are skipped — self-healing when a track was deleted
+    or a line is otherwise stale, and a hard guard against a malicious
+    or malformed M3U escaping the library root via ``../``.
+    """
+
+    download_dir = Path(download_dir).resolve()
+    m3u_dir = m3u_path.resolve().parent
+    try:
+        lines = m3u_path.read_text(encoding='utf-8').splitlines()
+    except OSError:
+        return []
+
+    tracks: list[str] = []
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith('#'):
+            continue
+        try:
+            resolved = (m3u_dir / line).resolve()
+            rel = resolved.relative_to(download_dir)
+        except (OSError, ValueError):
+            continue
+        if not resolved.is_file():
+            continue
+        tracks.append(rel.as_posix())
+    return tracks
+
+
 def write_m3u(
     download_dir: Path,
     playlist_name: str,

--- a/frontend/src/i18n/locales/el.js
+++ b/frontend/src/i18n/locales/el.js
@@ -230,6 +230,8 @@ export default {
     playFromLibrary: 'Άνοιγμα στο player',
     countOne: '{count} κομμάτι',
     countMany: '{count} κομμάτια',
+    playingFrom: 'Αναπαραγωγή από',
+    allSongs: 'Όλα τα τραγούδια ({count})',
   },
   footer: {
     tagline: 'Πρόγραμμα λήψης μουσικής ανοιχτού κώδικα',

--- a/frontend/src/i18n/locales/en.js
+++ b/frontend/src/i18n/locales/en.js
@@ -223,6 +223,8 @@ export default {
     playFromLibrary: 'Open in player',
     countOne: '{count} track',
     countMany: '{count} tracks',
+    playingFrom: 'Playing from',
+    allSongs: 'All Songs ({count})',
   },
   footer: {
     tagline: 'Open source music downloader',

--- a/frontend/src/i18n/locales/es.js
+++ b/frontend/src/i18n/locales/es.js
@@ -228,6 +228,8 @@ export default {
     playFromLibrary: 'Abrir en el reproductor',
     countOne: '{count} pista',
     countMany: '{count} pistas',
+    playingFrom: 'Reproduciendo desde',
+    allSongs: 'Todas las canciones ({count})',
   },
   footer: {
     tagline: 'Descargador de música de código abierto',

--- a/frontend/src/i18n/locales/fr.js
+++ b/frontend/src/i18n/locales/fr.js
@@ -229,6 +229,8 @@ export default {
     playFromLibrary: 'Ouvrir dans le lecteur',
     countOne: '{count} titre',
     countMany: '{count} titres',
+    playingFrom: 'Lecture depuis',
+    allSongs: 'Tous les titres ({count})',
   },
   footer: {
     tagline:

--- a/frontend/src/i18n/locales/hu.js
+++ b/frontend/src/i18n/locales/hu.js
@@ -229,6 +229,8 @@ export default {
     playFromLibrary: 'Megnyitás a lejátszóban',
     countOne: '{count} szám',
     countMany: '{count} szám',
+    playingFrom: 'Lejátszás innen',
+    allSongs: 'Összes szám ({count})',
   },
   footer: {
     tagline: 'Nyílt forráskódú zeneletöltő',

--- a/frontend/src/i18n/locales/pt-BR.js
+++ b/frontend/src/i18n/locales/pt-BR.js
@@ -227,6 +227,8 @@ export default {
     playFromLibrary: 'Abrir no player',
     countOne: '{count} faixa',
     countMany: '{count} faixas',
+    playingFrom: 'Tocando de',
+    allSongs: 'Todas as músicas ({count})',
   },
   footer: {
     tagline: 'Baixador de músicas de código aberto',

--- a/frontend/src/i18n/locales/tr.js
+++ b/frontend/src/i18n/locales/tr.js
@@ -220,6 +220,8 @@ export default {
     playFromLibrary: 'Oynatıcıda aç',
     countOne: '{count} parça',
     countMany: '{count} parça',
+    playingFrom: 'Şuradan çalıyor',
+    allSongs: 'Tüm Şarkılar ({count})',
   },
   footer: {
     tagline: 'Açık kaynak müzik indirme uygulaması',

--- a/frontend/src/model/api.js
+++ b/frontend/src/model/api.js
@@ -97,6 +97,10 @@ function listDownloads() {
   return API.get('/list')
 }
 
+function listPlaylists() {
+  return API.get('/playlists')
+}
+
 function deleteDownload(file) {
   return API.delete('/delete', { params: { file } })
 }
@@ -143,6 +147,7 @@ export default {
   downloadFileURL,
   coverFileURL,
   listDownloads,
+  listPlaylists,
   deleteDownload,
   writePlaylistM3u,
   getQueue,

--- a/frontend/src/model/player.js
+++ b/frontend/src/model/player.js
@@ -79,16 +79,40 @@ function buildShuffleOrder() {
       : 0
 }
 
+function sameTrackOrder(a, b) {
+  if (a.length !== b.length) return false
+  return a.every((track, i) => track.file === b[i].file)
+}
+
 function setPlaylist(files, options = {}) {
   const tracks = (files || []).map((f) =>
     typeof f === 'string' ? trackFromFile(f) : f
   )
+  if (
+    typeof options.startIndex !== 'number' &&
+    sameTrackOrder(tracks, playlist.value)
+  ) {
+    // Re-selecting the queue that's already loaded (e.g. re-picking the
+    // active playlist) must not interrupt what's currently playing.
+    return
+  }
   playlist.value = tracks
-  if (currentIndex.value >= tracks.length) currentIndex.value = -1
-  if (shuffle.value) buildShuffleOrder()
   if (typeof options.startIndex === 'number') {
     playAt(options.startIndex)
-  } else if (options.autoplay && tracks.length > 0 && currentIndex.value < 0) {
+    return
+  }
+  // Any other queue replacement drops whatever was playing/queued
+  // before — a stale currentIndex would otherwise point at an unrelated
+  // track in the new list that just happens to share the same position.
+  currentIndex.value = -1
+  pause()
+  if (audio) {
+    audio.removeAttribute('src')
+  }
+  currentTime.value = 0
+  duration.value = 0
+  if (shuffle.value) buildShuffleOrder()
+  if (options.autoplay && tracks.length > 0) {
     playAt(0)
   }
 }

--- a/frontend/src/views/Player.vue
+++ b/frontend/src/views/Player.vue
@@ -5,13 +5,37 @@
 
     <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6">
       <!-- Header -->
-      <div class="mb-8">
-        <h1 class="text-2xl font-bold tracking-tight">
-          {{ t('player.title') }}
-        </h1>
-        <p class="mt-1 text-sm text-base-content/60">
-          {{ t('player.subtitle') }}
-        </p>
+      <div
+        class="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between"
+      >
+        <div>
+          <h1 class="text-2xl font-bold tracking-tight">
+            {{ t('player.title') }}
+          </h1>
+          <p class="mt-1 text-sm text-base-content/60">
+            {{ t('player.subtitle') }}
+          </p>
+        </div>
+
+        <div v-if="playlists.length > 0" class="shrink-0">
+          <label
+            class="block text-xs font-semibold uppercase tracking-wider text-base-content/50 mb-1.5"
+          >
+            {{ t('player.playingFrom') }}
+          </label>
+          <select
+            v-model="selectedPlaylistName"
+            @change="onSelectPlaylist"
+            class="select select-sm w-full sm:w-64 rounded-xl bg-base-100/85 border border-white/10 focus:border-primary/60"
+          >
+            <option :value="null">
+              {{ t('player.allSongs', { count: files.length }) }}
+            </option>
+            <option v-for="pl in playlists" :key="pl.name" :value="pl.name">
+              {{ pl.name }} ({{ pl.count }})
+            </option>
+          </select>
+        </div>
       </div>
 
       <!-- Empty state -->
@@ -121,7 +145,7 @@
               class="icon-btn"
               @click="player.prev()"
               :title="t('player.previous')"
-              :disabled="files.length === 0"
+              :disabled="player.playlist.value.length === 0"
             >
               <Icon
                 icon="clarity:step-forward-2-line"
@@ -131,7 +155,7 @@
             <button
               class="inline-flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-content shadow-glow-sm hover:scale-105 active:scale-95 transition disabled:opacity-50"
               @click="player.toggle()"
-              :disabled="files.length === 0"
+              :disabled="player.playlist.value.length === 0"
               :title="
                 player.isPlaying.value ? t('player.pause') : t('player.play')
               "
@@ -149,7 +173,7 @@
               class="icon-btn"
               @click="player.next()"
               :title="t('player.next')"
-              :disabled="files.length === 0"
+              :disabled="player.playlist.value.length === 0"
             >
               <Icon icon="clarity:step-forward-2-line" class="h-5 w-5" />
             </button>
@@ -214,24 +238,28 @@
             </h2>
             <span class="text-[11px] text-base-content/40">
               {{
-                files.length === 1
-                  ? t('player.countOne', { count: files.length })
-                  : t('player.countMany', { count: files.length })
+                player.playlist.value.length === 1
+                  ? t('player.countOne', {
+                      count: player.playlist.value.length,
+                    })
+                  : t('player.countMany', {
+                      count: player.playlist.value.length,
+                    })
               }}
             </span>
           </div>
 
-          <ul v-if="files.length > 0" class="space-y-1">
+          <ul v-if="player.playlist.value.length > 0" class="space-y-1">
             <li
-              v-for="(file, idx) in files"
-              :key="file"
+              v-for="(track, idx) in player.playlist.value"
+              :key="track.file"
               class="rounded-xl px-2 py-2 flex items-center gap-3 cursor-pointer transition-colors"
               :class="
                 idx === player.currentIndex.value
                   ? 'bg-primary/10 text-primary'
                   : 'hover:bg-white/5'
               "
-              @click="onPick(idx)"
+              @click="player.playAt(idx)"
             >
               <div
                 class="relative h-9 w-9 shrink-0 rounded-lg overflow-hidden flex items-center justify-center"
@@ -242,12 +270,12 @@
                 "
               >
                 <img
-                  v-if="!coverFailed[file]"
-                  :src="coverUrlFor(file)"
-                  :alt="trackInfo(file).title"
+                  v-if="!coverFailed[track.file]"
+                  :src="track.cover"
+                  :alt="track.title"
                   class="absolute inset-0 h-full w-full object-cover"
                   loading="lazy"
-                  @error="markCoverFailed(file)"
+                  @error="markCoverFailed(track.file)"
                 />
                 <span
                   v-if="
@@ -259,17 +287,17 @@
                   <span></span><span></span><span></span>
                 </span>
                 <Icon
-                  v-else-if="coverFailed[file]"
+                  v-else-if="coverFailed[track.file]"
                   icon="clarity:music-note-line"
                   class="h-4 w-4 text-base-content/50"
                 />
               </div>
               <div class="flex-1 min-w-0">
                 <p class="text-sm truncate font-medium">
-                  {{ trackInfo(file).title }}
+                  {{ track.title }}
                 </p>
                 <p class="text-[11px] truncate text-base-content/50">
-                  {{ trackInfo(file).artist || t('common.unknownArtist') }}
+                  {{ track.artist || t('common.unknownArtist') }}
                 </p>
               </div>
             </li>
@@ -290,54 +318,69 @@ import { Icon } from '@iconify/vue'
 import Navbar from '/src/components/Navbar.vue'
 import Settings from '/src/components/Settings.vue'
 import API from '/src/model/api'
-import { usePlayer, formatTime, trackInfoFromFile } from '/src/model/player'
+import { usePlayer, formatTime } from '/src/model/player'
 import { useI18n } from '/src/i18n'
 
 const { t } = useI18n()
 const player = usePlayer()
 
 const files = ref([])
+const playlists = ref([])
+const selectedPlaylistName = ref(null) // null = "All Songs"
 const loading = ref(false)
 const progressBar = ref(null)
 const coverFailed = ref({})
 let dragging = false
 
-function coverUrlFor(file) {
-  return API.coverFileURL(file)
-}
-
 function markCoverFailed(file) {
   coverFailed.value = { ...coverFailed.value, [file]: true }
+}
+
+function filesForSelection(name) {
+  if (!name) return files.value
+  const pl = playlists.value.find((p) => p.name === name)
+  return pl ? pl.files : files.value
+}
+
+// Reflect whichever queue is already loaded (playback survives
+// navigating away and back) in the selector, instead of always
+// resetting it to "All Songs" on mount.
+function detectCurrentSelection() {
+  const current = player.playlist.value.map((track) => track.file)
+  if (current.length === 0) {
+    selectedPlaylistName.value = null
+    return
+  }
+  const match = playlists.value.find(
+    (pl) =>
+      pl.files.length === current.length &&
+      pl.files.every((f, i) => f === current[i])
+  )
+  selectedPlaylistName.value = match ? match.name : null
 }
 
 async function load() {
   loading.value = true
   try {
-    const res = await API.listDownloads()
-    files.value = res.data || []
+    const [libraryRes, playlistsRes] = await Promise.all([
+      API.listDownloads(),
+      API.listPlaylists(),
+    ])
+    files.value = libraryRes.data || []
+    playlists.value = playlistsRes.data || []
     // If the player was empty (direct nav to /player), seed the queue
-    // with the library so the user has something to play.
+    // with the full library so the user has something to play.
     if (player.playlist.value.length === 0 && files.value.length > 0) {
       player.setPlaylist(files.value)
     }
+    detectCurrentSelection()
   } finally {
     loading.value = false
   }
 }
 
-function onPick(idx) {
-  if (
-    player.playlist.value.length !== files.value.length ||
-    player.playlist.value[idx]?.file !== files.value[idx]
-  ) {
-    player.setPlaylist(files.value, { startIndex: idx })
-  } else {
-    player.playAt(idx)
-  }
-}
-
-function trackInfo(file) {
-  return trackInfoFromFile(file)
+function onSelectPlaylist() {
+  player.setPlaylist(filesForSelection(selectedPlaylistName.value))
 }
 
 const trackTitle = computed(() => {

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ from mutagen.oggopus import OggOpus
 from mutagen.oggvorbis import OggVorbis
 from uvicorn import Config, Server
 
-from downtify import __version__, api
+from downtify import __version__, api, m3u
 from downtify.downloader import Downloader
 from downtify.monitor import PlaylistMonitorDB, monitor_loop
 
@@ -259,6 +259,36 @@ def build_app() -> FastAPI:
             files.append(path.relative_to(base).as_posix())
         files.sort()
         return files
+
+    @app.get('/playlists')
+    def list_playlists() -> list[dict]:
+        """List downloaded playlists, derived from the ``.m3u`` files
+        Downtify already writes for playlist/album downloads and
+        Playlist Monitor sweeps (see ``downtify/m3u.py``).
+
+        Each M3U file on disk is one playlist, regardless of whether
+        *Organize by artist/album* put its tracks in a per-playlist
+        folder or scattered them into artist/album folders — the M3U is
+        the one place that still records "these tracks belong together,
+        in this order" either way. Single tracks and albums downloaded
+        without an M3U (e.g. via the YouTube Music album endpoint)
+        aren't playlists and don't show up here.
+        """
+        base = DOWNLOAD_DIR.resolve()
+        if not base.exists():
+            return []
+        playlists: list[dict] = []
+        for m3u_path in sorted(base.rglob('*.m3u')):
+            tracks = m3u.read_m3u_tracks(m3u_path, base)
+            if not tracks:
+                continue
+            playlists.append({
+                'name': m3u_path.stem,
+                'files': tracks,
+                'count': len(tracks),
+            })
+        playlists.sort(key=lambda p: p['name'].casefold())
+        return playlists
 
     @app.delete('/delete')
     def delete_download(file: str) -> dict:

--- a/tests/test_m3u.py
+++ b/tests/test_m3u.py
@@ -244,3 +244,94 @@ def test_write_overwrites_existing_m3u(tmp_path):
     )
     assert kept == 2
     assert 'b.mp3' in target.read_text(encoding='utf-8')
+
+
+# --- read_m3u_tracks ---------------------------------------------------------
+
+
+def test_read_round_trips_central_playlists_dir(tmp_path):
+    _touch(tmp_path, 'a.mp3')
+    _touch(tmp_path, 'b.mp3')
+    target, _ = m3u.write_m3u(
+        tmp_path,
+        'Mix',
+        [{'filename': 'a.mp3'}, {'filename': 'b.mp3'}],
+    )
+    assert m3u.read_m3u_tracks(target, tmp_path) == ['a.mp3', 'b.mp3']
+
+
+def test_read_round_trips_per_playlist_subdir(tmp_path):
+    pl_dir = tmp_path / 'My Mix'
+    pl_dir.mkdir()
+    (pl_dir / 'Artist - Song.mp3').write_bytes(b'\x00')
+    target, _ = m3u.write_m3u(
+        tmp_path,
+        'My Mix',
+        [{'filename': 'My Mix/Artist - Song.mp3'}],
+        playlist_subdir='My Mix',
+    )
+    assert m3u.read_m3u_tracks(target, tmp_path) == [
+        'My Mix/Artist - Song.mp3'
+    ]
+
+
+def test_read_preserves_track_order(tmp_path):
+    _touch(tmp_path, 'c.mp3')
+    _touch(tmp_path, 'a.mp3')
+    _touch(tmp_path, 'b.mp3')
+    target, _ = m3u.write_m3u(
+        tmp_path,
+        'Mix',
+        [
+            {'filename': 'c.mp3'},
+            {'filename': 'a.mp3'},
+            {'filename': 'b.mp3'},
+        ],
+    )
+    assert m3u.read_m3u_tracks(target, tmp_path) == [
+        'c.mp3',
+        'a.mp3',
+        'b.mp3',
+    ]
+
+
+def test_read_skips_deleted_tracks(tmp_path):
+    _touch(tmp_path, 'a.mp3')
+    b = _touch(tmp_path, 'b.mp3')
+    target, _ = m3u.write_m3u(
+        tmp_path, 'Mix', [{'filename': 'a.mp3'}, {'filename': 'b.mp3'}]
+    )
+    b.unlink()
+    assert m3u.read_m3u_tracks(target, tmp_path) == ['a.mp3']
+
+
+def test_read_ignores_extm3u_and_extinf_lines(tmp_path):
+    _touch(tmp_path, 'a.mp3')
+    target, _ = m3u.write_m3u(
+        tmp_path, 'Mix', [{'filename': 'a.mp3', 'title': 'Song'}]
+    )
+    body = target.read_text(encoding='utf-8')
+    assert body.startswith('#EXTM3U\n#EXTINF:')
+    assert m3u.read_m3u_tracks(target, tmp_path) == ['a.mp3']
+
+
+def test_read_returns_empty_list_for_missing_file(tmp_path):
+    assert m3u.read_m3u_tracks(tmp_path / 'nope.m3u', tmp_path) == []
+
+
+def test_read_rejects_path_traversal_outside_download_dir(tmp_path):
+    # A track path that escapes download_dir (e.g. a hand-edited or
+    # malicious M3U) must never be surfaced.
+    outside = tmp_path.parent / 'outside.mp3'
+    outside.write_bytes(b'\x00')
+    m3u_dir = tmp_path / 'Playlists'
+    m3u_dir.mkdir()
+    m3u_path = m3u_dir / 'Mix.m3u'
+    m3u_path.write_text(f'#EXTM3U\n../../{outside.name}\n', encoding='utf-8')
+    assert m3u.read_m3u_tracks(m3u_path, tmp_path) == []
+
+
+def test_read_empty_playlist_returns_empty_list(tmp_path):
+    m3u_path = tmp_path / 'Empty.m3u'
+    m3u_path.write_text('#EXTM3U\n', encoding='utf-8')
+    assert m3u.read_m3u_tracks(m3u_path, tmp_path) == []


### PR DESCRIPTION
Previously the player always queued every downloaded file at once, independent of which playlist a track belonged to. Adds a "Playing from" selector: All Songs (existing behavior, still the default) or one specific downloaded playlist.

Playlists are derived from the .m3u files Downtify already writes for playlist/album downloads, CSV imports and Playlist Monitor sweeps — no new playlist database, and it works retroactively on everything already downloaded. A single track or an album downloaded without an M3U (e.g. via the YouTube Music album endpoint) isn't a "playlist" by this definition and stays part of All Songs only.

- downtify/m3u.py: read_m3u_tracks() inverts the relative-path scheme write_m3u() already uses, turning an .m3u back into a list of download-dir-relative file paths (the same shape GET /list returns, so the frontend can feed it straight into the existing player queue code). Skips tracks that no longer exist on disk (self-healing) and guards against a path escaping download_dir via ../ in a malformed or hand-edited M3U.
- main.py: new GET /playlists, alongside the existing GET /list. Walks the downloads directory for *.m3u files (both placements write_m3u uses: the central Playlists/ dir and a per-playlist subfolder both get found), reads each with read_m3u_tracks(), and returns {name, files, count} per playlist that still has at least one track on disk.
- frontend: Player.vue gets the selector (only shown when at least one playlist exists); the side queue now renders the actually-loaded queue (player.playlist) instead of always the full library, so it stays correct once the two can differ. Restores whichever queue was last loaded when reopening the player, since playback state persists across navigation.
- model/player.js: setPlaylist() previously only reset currentIndex when the new list was shorter than before, so switching to a same-or-longer list without an explicit startIndex could leave a stale index pointing at position N of the new list while audio.src kept playing the old track at that position — UI and audio would disagree about what's "now playing". No caller needed the old preserve-index behavior (every existing call site already passes startIndex), so setPlaylist() now always stops playback and resets to unstarted on a genuine queue swap, and is a no-op when the new list is identical to what's already loaded (so re-selecting the active playlist doesn't interrupt it).

Verified against a real running server with two on-disk playlists laid out both ways write_m3u supports (central Playlists/*.m3u and a per-playlist subfolder M3U) plus a loose, non-playlist track: GET /playlists and GET /list both returned exactly the expected shapes. Confirmed the built bundle ships the new strings and the /playlists call. Could not click through the picker in an actual browser — no browser automation tool is available in this environment; verification above (real backend data + build output + code review of the setPlaylist fix) is the strongest available substitute, stated explicitly per the project's manual-verification requirement.

Tests: 9 new in tests/test_m3u.py for read_m3u_tracks (round-trips both M3U placements, skips deleted tracks, ignores #EXTM3U/#EXTINF lines, rejects path traversal — confirmed this fails if the traversal guard is removed, empty file, missing file). Full suite: 465 passed.

Docs: docs/features/player.md (new "Playing a single playlist" section) and docs/api-reference.md (GET /playlists); brief pointer added to README.md per the project's README-is-an-overview / docs-has-the-detail split.

close #259