### PR TITLE
style: Fix scrollbar poking past rounded corners

### DIFF
--- a/frontend/src/components/Settings.vue
+++ b/frontend/src/components/Settings.vue
@@ -2,11 +2,15 @@
   <input type="checkbox" id="settings-modal" class="modal-toggle" />
   <div class="modal modal-bottom sm:modal-middle">
     <div
-      class="modal-box surface-strong rounded-t-3xl sm:rounded-3xl p-0 max-w-lg"
+      class="modal-box surface-strong rounded-t-3xl sm:rounded-3xl p-0 max-w-lg overflow-hidden flex flex-col"
     >
       <!-- Header -->
+      <!-- overflow-hidden + flex-col on modal-box (above) clips the body's
+           scrollbar to the rounded corners instead of it poking past them
+           (daisyUI's .modal-box ships overflow-y:auto directly on the
+           rounded element, which native scrollbars don't respect). -->
       <div
-        class="flex items-center justify-between px-6 py-4 border-b border-white/5"
+        class="shrink-0 flex items-center justify-between px-6 py-4 border-b border-white/5"
       >
         <div>
           <h3 class="text-lg font-bold tracking-tight">
@@ -26,7 +30,7 @@
       </div>
 
       <!-- Body -->
-      <div class="px-6 py-5 space-y-6">
+      <div class="px-6 py-5 space-y-6 overflow-y-auto min-h-0">
         <!-- Language -->
         <div>
           <label
@@ -498,7 +502,7 @@
 
       <!-- Footer -->
       <div
-        class="flex items-center justify-end gap-2 px-6 py-4 border-t border-white/5"
+        class="shrink-0 flex items-center justify-end gap-2 px-6 py-4 border-t border-white/5"
       >
         <label
           for="settings-modal"

--- a/frontend/src/views/Player.vue
+++ b/frontend/src/views/Player.vue
@@ -227,84 +227,91 @@
         </section>
 
         <!-- Queue list -->
-        <aside
-          class="surface rounded-3xl p-4 sm:p-5 lg:max-h-[640px] lg:overflow-y-auto"
-        >
-          <div class="flex items-center justify-between mb-3 px-1">
-            <h2
-              class="text-xs font-semibold uppercase tracking-wider text-base-content/50"
-            >
-              {{ t('player.queue') }}
-            </h2>
-            <span class="text-[11px] text-base-content/40">
-              {{
-                player.playlist.value.length === 1
-                  ? t('player.countOne', {
-                      count: player.playlist.value.length,
-                    })
-                  : t('player.countMany', {
-                      count: player.playlist.value.length,
-                    })
-              }}
-            </span>
-          </div>
+        <!-- overflow-hidden lives on the outer wrapper so the rounded
+             corners clip the inner scrollbar instead of it poking past
+             them (native scrollbars ignore border-radius on the element
+             they scroll). -->
+        <aside class="surface rounded-3xl overflow-hidden lg:max-h-[640px]">
+          <div class="p-4 sm:p-5 lg:max-h-[640px] lg:overflow-y-auto">
+            <div class="flex items-center justify-between mb-3 px-1">
+              <h2
+                class="text-xs font-semibold uppercase tracking-wider text-base-content/50"
+              >
+                {{ t('player.queue') }}
+              </h2>
+              <span class="text-[11px] text-base-content/40">
+                {{
+                  player.playlist.value.length === 1
+                    ? t('player.countOne', {
+                        count: player.playlist.value.length,
+                      })
+                    : t('player.countMany', {
+                        count: player.playlist.value.length,
+                      })
+                }}
+              </span>
+            </div>
 
-          <ul v-if="player.playlist.value.length > 0" class="space-y-1">
-            <li
-              v-for="(track, idx) in player.playlist.value"
-              :key="track.file"
-              class="rounded-xl px-2 py-2 flex items-center gap-3 cursor-pointer transition-colors"
-              :class="
-                idx === player.currentIndex.value
-                  ? 'bg-primary/10 text-primary'
-                  : 'hover:bg-white/5'
-              "
-              @click="player.playAt(idx)"
-            >
-              <div
-                class="relative h-9 w-9 shrink-0 rounded-lg overflow-hidden flex items-center justify-center"
+            <ul v-if="player.playlist.value.length > 0" class="space-y-1">
+              <li
+                v-for="(track, idx) in player.playlist.value"
+                :key="track.file"
+                class="rounded-xl px-2 py-2 flex items-center gap-3 cursor-pointer transition-colors"
                 :class="
                   idx === player.currentIndex.value
-                    ? 'bg-primary/15'
-                    : 'bg-base-100/60'
+                    ? 'bg-primary/10 text-primary'
+                    : 'hover:bg-white/5'
                 "
+                @click="player.playAt(idx)"
               >
-                <img
-                  v-if="!coverFailed[track.file]"
-                  :src="track.cover"
-                  :alt="track.title"
-                  class="absolute inset-0 h-full w-full object-cover"
-                  loading="lazy"
-                  @error="markCoverFailed(track.file)"
-                />
-                <span
-                  v-if="
-                    idx === player.currentIndex.value && player.isPlaying.value
+                <div
+                  class="relative h-9 w-9 shrink-0 rounded-lg overflow-hidden flex items-center justify-center"
+                  :class="
+                    idx === player.currentIndex.value
+                      ? 'bg-primary/15'
+                      : 'bg-base-100/60'
                   "
-                  class="relative equalizer h-3"
-                  aria-hidden="true"
                 >
-                  <span></span><span></span><span></span>
-                </span>
-                <Icon
-                  v-else-if="coverFailed[track.file]"
-                  icon="clarity:music-note-line"
-                  class="h-4 w-4 text-base-content/50"
-                />
-              </div>
-              <div class="flex-1 min-w-0">
-                <p class="text-sm truncate font-medium">
-                  {{ track.title }}
-                </p>
-                <p class="text-[11px] truncate text-base-content/50">
-                  {{ track.artist || t('common.unknownArtist') }}
-                </p>
-              </div>
-            </li>
-          </ul>
+                  <img
+                    v-if="!coverFailed[track.file]"
+                    :src="track.cover"
+                    :alt="track.title"
+                    class="absolute inset-0 h-full w-full object-cover"
+                    loading="lazy"
+                    @error="markCoverFailed(track.file)"
+                  />
+                  <span
+                    v-if="
+                      idx === player.currentIndex.value &&
+                      player.isPlaying.value
+                    "
+                    class="relative equalizer h-3"
+                    aria-hidden="true"
+                  >
+                    <span></span><span></span><span></span>
+                  </span>
+                  <Icon
+                    v-else-if="coverFailed[track.file]"
+                    icon="clarity:music-note-line"
+                    class="h-4 w-4 text-base-content/50"
+                  />
+                </div>
+                <div class="flex-1 min-w-0">
+                  <p class="text-sm truncate font-medium">
+                    {{ track.title }}
+                  </p>
+                  <p class="text-[11px] truncate text-base-content/50">
+                    {{ track.artist || t('common.unknownArtist') }}
+                  </p>
+                </div>
+              </li>
+            </ul>
 
-          <div v-else class="text-center py-10">
-            <p class="text-base-content/50 text-sm">{{ t('player.empty') }}</p>
+            <div v-else class="text-center py-10">
+              <p class="text-base-content/50 text-sm">
+                {{ t('player.empty') }}
+              </p>
+            </div>
           </div>
         </aside>
       </div>


### PR DESCRIPTION
- Fix native scrollbar rendering square-cornered outside rounded containers (Player queue list, Settings modal). Native scrollbars ignore the border-radius of the element they scroll on, so `overflow-y: auto` + `rounded-*` on the same element lets the scrollbar poke past the curve. Moved `overflow-hidden` + the rounded corners to an outer wrapper and `overflow-y-auto` to an inner content element instead:
  - `views/Player.vue`: queue `<aside>` now wraps an inner scrollable div.
  - `components/Settings.vue`: `.modal-box` (which ships daisyUI's own `overflow-y: auto`) is now `overflow-hidden flex flex-col` with header/footer `shrink-0` and the body scrolling internally.

fix #312