### PR TITLE
feat: filter by playlist, artist or album (same as player)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,9 +240,11 @@ Downtify ships with a clean web player so you don't need a separate app to liste
 - **Repeat** modes: off → all → one
 - Volume slider with mute toggle (volume is remembered between sessions)
 - Side queue listing every track in your library, each one with its own thumbnail and the currently playing one highlighted
-- **Playing from** selector — play just one downloaded playlist instead of your whole library queued at once. See **[Built-in Player](https://henriquesebastiao.github.io/downtify/features/player/)** in the full docs.
+- **Playing from** selector — play just one downloaded playlist, artist or album instead of your whole library queued at once. See **[Built-in Player](https://henriquesebastiao.github.io/downtify/features/player/)** in the full docs.
 
 The player parses `Artist - Title.ext` filenames so the now-playing card shows artist and title nicely, and pulls the cover art directly from the audio file's embedded tags (the same artwork Downtify wrote at download time). Playback uses your browser's native HTML5 audio element — no extra dependencies, no extra processes.
+
+The **Library** page has the same playlist/artist/album filter to narrow down the file list before playing, re-downloading or deleting a track.
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -231,7 +231,7 @@ List all audio files in the downloads directory (recursive).
 
 ### `GET /playlists`
 
-List downloaded playlists, derived from the `.m3u` files already on disk (see [M3U Export](features/m3u-export.md)). Used by the [Built-in Player](features/player.md#playing-a-single-playlist) to offer "play just this playlist" instead of the whole library.
+List downloaded playlists, derived from the `.m3u` files already on disk (see [M3U Export](features/m3u-export.md)). Used by the [Built-in Player](features/player.md#playing-a-single-playlist-artist-or-album) and the Library page to offer "just this playlist" instead of the whole library.
 
 **Response:**
 
@@ -242,6 +242,22 @@ List downloaded playlists, derived from the `.m3u` files already on disk (see [M
 ```
 
 Sorted by name. A single track or an album downloaded without an M3U doesn't appear here.
+
+---
+
+### `GET /tracks`
+
+List downloaded tracks with artist/album read from each file's embedded tags. Used by the [Built-in Player](features/player.md#playing-a-single-playlist-artist-or-album) and the Library page to offer "just this artist" / "just this album" filtering.
+
+**Response:**
+
+```json
+[
+  { "file": "Artist - Song.mp3", "artist": "Artist", "album": "Some Album" }
+]
+```
+
+Sorted by `file`, same order as `/list`. `artist`/`album` come back as `""` when the file has no readable tag for that field — the frontend then simply doesn't offer it as a filter for that track.
 
 ---
 

--- a/docs/features/player.md
+++ b/docs/features/player.md
@@ -15,17 +15,22 @@ Downtify ships with a web player so you can listen to your downloaded music with
 - **Repeat modes** — off → repeat all → repeat one
 - **Volume slider** — with mute toggle; your volume level is saved between sessions
 - **Side queue** — all tracks in your library, each with its own thumbnail; the currently playing track is highlighted
-- **Playing from** — pick **All Songs** or one specific downloaded playlist, instead of always queuing your whole library
+- **Playing from** — pick **All Songs**, one specific downloaded playlist, one artist, or one album, instead of always queuing your whole library
 
-## Playing a single playlist
+## Playing a single playlist, artist or album
 
-By default the player queues every downloaded track. Use the **Playing from** selector next to the page title to switch the queue to just one playlist. This picks up any playlist that has an [M3U file](m3u-export.md) — playlist and album downloads, [CSV imports](library-import.md), and [Playlist Monitor](playlist-monitor.md) all write one automatically, so this works retroactively on everything you've already downloaded. A single track or an album downloaded without an M3U (e.g. via the YouTube Music album flow) isn't a "playlist" and won't appear in the list — it's still part of **All Songs**.
+By default the player queues every downloaded track. Use the **Playing from** selector next to the page title to narrow the queue down:
 
-Switching playlists replaces the queue and stops whatever was playing; pick a track or hit play to start the new one. Reopening the player later resumes whichever queue (all songs or a specific playlist) was last loaded.
+- **Playlists** — picks up any playlist that has an [M3U file](m3u-export.md). Playlist and album downloads, [CSV imports](library-import.md), and [Playlist Monitor](playlist-monitor.md) all write one automatically, so this works retroactively on everything you've already downloaded. A single track or an album downloaded without an M3U (e.g. via the YouTube Music album flow) isn't a "playlist" and won't appear in this group — it's still part of **All Songs**.
+- **Artists** and **Albums** — built from each file's embedded artist/album tags, so they list every artist and album you've ever downloaded regardless of how the files are organized on disk (loose in the library root, in per-playlist folders, or in `Artist/Album` folders when [*Organize by artist/album*](file-organization.md) is on). A track with no artist or album tag simply isn't a member of either group, but it's still part of **All Songs**.
+
+Switching the selection replaces the queue and stops whatever was playing; pick a track or hit play to start the new one. Reopening the player later resumes whichever queue (all songs, a playlist, an artist, or an album) was last loaded.
+
+The Library page (the file browser in the navigation bar) has the same **Filter by** selector, built from the same playlist/artist/album data — use it to narrow down the file list before deleting, re-downloading, or hitting play on a track, instead of scrolling through the whole library.
 
 ## How it works
 
-The player loads every audio file found recursively inside the downloads directory. Files are served directly from the container via the `/downloads` static mount. The playlist selector is built from the `.m3u` files already on disk — no separate playlist database.
+The player loads every audio file found recursively inside the downloads directory. Files are served directly from the container via the `/downloads` static mount. The playlist group is built from the `.m3u` files already on disk (`GET /playlists`); the artist/album groups are built from each file's embedded tags (`GET /tracks`) — no separate playlist or library database.
 
 Filenames in the format `Artist - Title.ext` are parsed so the now-playing card can show artist and title cleanly. Cover art is fetched on demand from the `/cover` endpoint, which reads the embedded image tags from the file itself — the same artwork Downtify wrote at download time.
 

--- a/frontend/src/i18n/locales/bg.js
+++ b/frontend/src/i18n/locales/bg.js
@@ -84,6 +84,9 @@ export default {
     downloadToDevice: 'Запис на устройство',
     deleteFile: 'Изтрий файл',
     play: 'Пусни',
+    filterBy: 'Филтрирай по',
+    filterEmpty: 'Няма файлове, отговарящи на този филтър.',
+    clearFilter: 'Изчисти филтъра',
   },
   monitor: {
     title: 'Следене на плейлист',
@@ -236,6 +239,9 @@ export default {
     countMany: '{count} песни',
     playingFrom: 'Възпроизвеждане от',
     allSongs: 'Всички песни ({count})',
+    playlistsGroup: 'Плейлисти',
+    artistsGroup: 'Изпълнители',
+    albumsGroup: 'Албуми',
   },
   footer: {
     tagline: 'Приложение за теглене на музика с отворен код',

--- a/frontend/src/i18n/locales/el.js
+++ b/frontend/src/i18n/locales/el.js
@@ -88,6 +88,9 @@ export default {
     downloadToDevice: 'Λήψη στη συσκευή',
     deleteFile: 'Διαγραφή αρχείου',
     play: 'Αναπαραγωγή',
+    filterBy: 'Φιλτράρισμα κατά',
+    filterEmpty: 'Κανένα αρχείο δεν ταιριάζει με αυτό το φίλτρο.',
+    clearFilter: 'Καθαρισμός φίλτρου',
   },
   monitor: {
     title: 'Παρακολούθηση Playlist',
@@ -243,6 +246,9 @@ export default {
     countMany: '{count} κομμάτια',
     playingFrom: 'Αναπαραγωγή από',
     allSongs: 'Όλα τα τραγούδια ({count})',
+    playlistsGroup: 'Λίστες αναπαραγωγής',
+    artistsGroup: 'Καλλιτέχνες',
+    albumsGroup: 'Άλμπουμ',
   },
   footer: {
     tagline: 'Πρόγραμμα λήψης μουσικής ανοιχτού κώδικα',

--- a/frontend/src/i18n/locales/en.js
+++ b/frontend/src/i18n/locales/en.js
@@ -85,6 +85,9 @@ export default {
     downloadToDevice: 'Download to device',
     deleteFile: 'Delete file',
     play: 'Play',
+    filterBy: 'Filter by',
+    filterEmpty: 'No files match this filter.',
+    clearFilter: 'Clear filter',
   },
   monitor: {
     title: 'Playlist Monitor',
@@ -237,6 +240,9 @@ export default {
     countMany: '{count} tracks',
     playingFrom: 'Playing from',
     allSongs: 'All Songs ({count})',
+    playlistsGroup: 'Playlists',
+    artistsGroup: 'Artists',
+    albumsGroup: 'Albums',
   },
   footer: {
     tagline: 'Open source music downloader',

--- a/frontend/src/i18n/locales/es.js
+++ b/frontend/src/i18n/locales/es.js
@@ -88,6 +88,9 @@ export default {
     downloadToDevice: 'Descargar al dispositivo',
     deleteFile: 'Eliminar archivo',
     play: 'Reproducir',
+    filterBy: 'Filtrar por',
+    filterEmpty: 'Ningún archivo coincide con este filtro.',
+    clearFilter: 'Quitar filtro',
   },
   monitor: {
     title: 'Monitor de listas',
@@ -243,6 +246,9 @@ export default {
     countMany: '{count} pistas',
     playingFrom: 'Reproduciendo desde',
     allSongs: 'Todas las canciones ({count})',
+    playlistsGroup: 'Listas de reproducción',
+    artistsGroup: 'Artistas',
+    albumsGroup: 'Álbumes',
   },
   footer: {
     tagline: 'Descargador de música de código abierto',

--- a/frontend/src/i18n/locales/fr.js
+++ b/frontend/src/i18n/locales/fr.js
@@ -90,6 +90,9 @@ export default {
     downloadToDevice: "Télécharger sur l'appareil",
     deleteFile: 'Supprimer le fichier',
     play: 'Lecture',
+    filterBy: 'Filtrer par',
+    filterEmpty: 'Aucun fichier ne correspond à ce filtre.',
+    clearFilter: 'Effacer le filtre',
   },
   monitor: {
     title: 'Surveillance des listes de lecture',
@@ -242,6 +245,9 @@ export default {
     countMany: '{count} titres',
     playingFrom: 'Lecture depuis',
     allSongs: 'Tous les titres ({count})',
+    playlistsGroup: 'Playlists',
+    artistsGroup: 'Artistes',
+    albumsGroup: 'Albums',
   },
   footer: {
     tagline:

--- a/frontend/src/i18n/locales/hu.js
+++ b/frontend/src/i18n/locales/hu.js
@@ -88,6 +88,9 @@ export default {
 
     deleteFile: 'Fájl törlése',
     play: 'Lejátszás',
+    filterBy: 'Szűrés',
+    filterEmpty: 'Nincs a szűrőnek megfelelő fájl.',
+    clearFilter: 'Szűrő törlése',
   },
   monitor: {
     title: 'Lejátszási lista felügyelő',
@@ -242,6 +245,9 @@ export default {
     countMany: '{count} szám',
     playingFrom: 'Lejátszás innen',
     allSongs: 'Összes szám ({count})',
+    playlistsGroup: 'Lejátszási listák',
+    artistsGroup: 'Előadók',
+    albumsGroup: 'Albumok',
   },
   footer: {
     tagline: 'Nyílt forráskódú zeneletöltő',

--- a/frontend/src/i18n/locales/pt-BR.js
+++ b/frontend/src/i18n/locales/pt-BR.js
@@ -87,6 +87,9 @@ export default {
     downloadToDevice: 'Baixar para o dispositivo',
     deleteFile: 'Excluir arquivo',
     play: 'Reproduzir',
+    filterBy: 'Filtrar por',
+    filterEmpty: 'Nenhum arquivo corresponde a este filtro.',
+    clearFilter: 'Limpar filtro',
   },
   monitor: {
     title: 'Monitor de playlists',
@@ -242,6 +245,9 @@ export default {
     countMany: '{count} faixas',
     playingFrom: 'Tocando de',
     allSongs: 'Todas as músicas ({count})',
+    playlistsGroup: 'Playlists',
+    artistsGroup: 'Artistas',
+    albumsGroup: 'Álbuns',
   },
   footer: {
     tagline: 'Baixador de músicas de código aberto',

--- a/frontend/src/i18n/locales/tr.js
+++ b/frontend/src/i18n/locales/tr.js
@@ -83,6 +83,9 @@ export default {
     downloadToDevice: 'Cihaza indir',
     deleteFile: 'Dosyayı sil',
     play: 'Oynat',
+    filterBy: 'Filtrele',
+    filterEmpty: 'Bu filtreyle eşleşen dosya yok.',
+    clearFilter: 'Filtreyi temizle',
   },
   monitor: {
     title: 'Çalma Listesi İzleyici',
@@ -234,6 +237,9 @@ export default {
     countMany: '{count} parça',
     playingFrom: 'Şuradan çalıyor',
     allSongs: 'Tüm Şarkılar ({count})',
+    playlistsGroup: 'Çalma Listeleri',
+    artistsGroup: 'Sanatçılar',
+    albumsGroup: 'Albümler',
   },
   footer: {
     tagline: 'Açık kaynak müzik indirme uygulaması',

--- a/frontend/src/model/api.js
+++ b/frontend/src/model/api.js
@@ -101,6 +101,10 @@ function listPlaylists() {
   return API.get('/playlists')
 }
 
+function listTracks() {
+  return API.get('/tracks')
+}
+
 function deleteDownload(file) {
   return API.delete('/delete', { params: { file } })
 }
@@ -148,6 +152,7 @@ export default {
   coverFileURL,
   listDownloads,
   listPlaylists,
+  listTracks,
   deleteDownload,
   writePlaylistM3u,
   getQueue,

--- a/frontend/src/model/trackGroups.js
+++ b/frontend/src/model/trackGroups.js
@@ -1,0 +1,74 @@
+// Shared grouping helpers for the "play/filter by playlist, artist or
+// album" selector used by both the Player and Library pages. Both pages
+// fetch the same `/tracks` (file + artist + album) and `/playlists`
+// (M3U-derived) data and just render it differently, so the bucketing
+// logic lives here once.
+
+/**
+ * Bucket `tracks` (as returned by `GET /tracks`) by the given tag field
+ * ('artist' or 'album') into filterable groups. Tracks with no value for
+ * that field aren't a member of any group — an untagged file is still
+ * reachable via "All Songs", it just isn't a filter target itself.
+ */
+export function buildGroups(tracks, field) {
+  const map = new Map()
+  for (const tr of tracks) {
+    const name = (tr[field] || '').trim()
+    if (!name) continue
+    if (!map.has(name)) map.set(name, [])
+    map.get(name).push(tr.file)
+  }
+  return Array.from(map.entries())
+    .map(([name, groupFiles]) => ({
+      name,
+      files: groupFiles,
+      count: groupFiles.length,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+/**
+ * Resolve the file list for a selector value, where `group` is either
+ * `null` (all files) or `{ type: 'playlist' | 'artist' | 'album', name }`.
+ */
+export function filesForGroup(
+  group,
+  { files, playlists, artistGroups, albumGroups }
+) {
+  if (!group) return files
+  const groups =
+    group.type === 'playlist'
+      ? playlists
+      : group.type === 'artist'
+        ? artistGroups
+        : albumGroups
+  const match = groups.find((g) => g.name === group.name)
+  return match ? match.files : files
+}
+
+/**
+ * Match an already-loaded file list back to whichever group it came
+ * from (playlist, artist or album), so a selector can reflect a
+ * selection restored from elsewhere (e.g. the player resuming its
+ * last queue) instead of always resetting to "All Songs".
+ */
+export function detectGroup(
+  currentFiles,
+  { playlists, artistGroups, albumGroups }
+) {
+  if (currentFiles.length === 0) return null
+  const sources = [
+    ['playlist', playlists],
+    ['artist', artistGroups],
+    ['album', albumGroups],
+  ]
+  for (const [type, groups] of sources) {
+    const match = groups.find(
+      (g) =>
+        g.files.length === currentFiles.length &&
+        g.files.every((f, i) => f === currentFiles[i])
+    )
+    if (match) return { type, name: match.name }
+  }
+  return null
+}

--- a/frontend/src/views/Downloads.vue
+++ b/frontend/src/views/Downloads.vue
@@ -16,7 +16,7 @@
         </div>
         <div class="flex items-center gap-2">
           <button
-            v-if="files.length > 0"
+            v-if="filteredFiles.length > 0"
             class="btn btn-primary btn-sm h-11 px-5 rounded-full"
             @click="playAll"
             :title="t('library.play')"
@@ -37,6 +37,59 @@
             {{ t('common.refresh') }}
           </button>
         </div>
+      </div>
+
+      <!-- Filter by playlist / artist / album -->
+      <div v-if="hasFilterableGroups" class="mb-6">
+        <label
+          class="block text-xs font-semibold uppercase tracking-wider text-base-content/50 mb-1.5"
+        >
+          {{ t('library.filterBy') }}
+        </label>
+        <select
+          v-model="selectedGroup"
+          class="select select-sm w-full sm:w-64 rounded-xl bg-base-100/85 border border-white/10 focus:border-primary/60"
+        >
+          <option :value="null">
+            {{ t('player.allSongs', { count: files.length }) }}
+          </option>
+          <optgroup
+            v-if="playlists.length > 0"
+            :label="t('player.playlistsGroup')"
+          >
+            <option
+              v-for="pl in playlists"
+              :key="'playlist-' + pl.name"
+              :value="{ type: 'playlist', name: pl.name }"
+            >
+              {{ pl.name }} ({{ pl.count }})
+            </option>
+          </optgroup>
+          <optgroup
+            v-if="artistGroups.length > 0"
+            :label="t('player.artistsGroup')"
+          >
+            <option
+              v-for="a in artistGroups"
+              :key="'artist-' + a.name"
+              :value="{ type: 'artist', name: a.name }"
+            >
+              {{ a.name }} ({{ a.count }})
+            </option>
+          </optgroup>
+          <optgroup
+            v-if="albumGroups.length > 0"
+            :label="t('player.albumsGroup')"
+          >
+            <option
+              v-for="al in albumGroups"
+              :key="'album-' + al.name"
+              :value="{ type: 'album', name: al.name }"
+            >
+              {{ al.name }} ({{ al.count }})
+            </option>
+          </optgroup>
+        </select>
       </div>
 
       <!-- Error -->
@@ -66,6 +119,26 @@
         <p class="text-base-content/40 text-xs mt-1">
           {{ t('library.emptyHint') }}
         </p>
+      </div>
+
+      <!-- Filter matched nothing (library itself isn't empty) -->
+      <div
+        v-else-if="filteredFiles.length === 0"
+        class="surface rounded-2xl p-12 flex flex-col items-center text-center"
+      >
+        <Icon
+          icon="clarity:search-line"
+          class="h-12 w-12 text-base-content/20 mb-4"
+        />
+        <p class="text-base-content/50 text-sm">
+          {{ t('library.filterEmpty') }}
+        </p>
+        <button
+          class="mt-3 text-xs text-primary hover:underline"
+          @click="selectedGroup = null"
+        >
+          {{ t('library.clearFilter') }}
+        </button>
       </div>
 
       <!-- File list -->
@@ -110,7 +183,7 @@
           <div class="flex items-center gap-1 shrink-0">
             <button
               class="icon-btn text-primary hover:bg-primary/10"
-              @click="playFile(files.indexOf(file))"
+              @click="playFile(file)"
               :title="t('library.play')"
             >
               <Icon icon="clarity:play-line" class="h-4 w-4" />
@@ -177,13 +250,13 @@
 
       <!-- Count footer -->
       <p
-        v-if="files.length > 0"
+        v-if="filteredFiles.length > 0"
         class="mt-6 text-xs text-base-content/40 text-center"
       >
         {{
-          files.length === 1
-            ? t('library.countOne', { count: files.length })
-            : t('library.countMany', { count: files.length })
+          filteredFiles.length === 1
+            ? t('library.countOne', { count: filteredFiles.length })
+            : t('library.countMany', { count: filteredFiles.length })
         }}
       </p>
     </div>
@@ -199,6 +272,7 @@ import Settings from '/src/components/Settings.vue'
 import API from '/src/model/api'
 import { useI18n } from '/src/i18n'
 import { usePlayer } from '/src/model/player'
+import { buildGroups, filesForGroup } from '/src/model/trackGroups'
 
 const PAGE_SIZE = 10
 
@@ -207,20 +281,45 @@ const player = usePlayer()
 const router = useRouter()
 
 const files = ref([])
+const tracks = ref([]) // [{ file, artist, album }] — from GET /tracks
+const playlists = ref([])
+// null = "All Songs"; otherwise { type: 'playlist' | 'artist' | 'album', name }
+const selectedGroup = ref(null)
 const loading = ref(false)
 const error = ref('')
 const deleting = ref({})
 const coverFailed = ref({})
 const currentPage = ref(1)
 
-const totalPages = computed(() => Math.ceil(files.value.length / PAGE_SIZE))
+const artistGroups = computed(() => buildGroups(tracks.value, 'artist'))
+const albumGroups = computed(() => buildGroups(tracks.value, 'album'))
+
+const hasFilterableGroups = computed(
+  () =>
+    playlists.value.length > 0 ||
+    artistGroups.value.length > 0 ||
+    albumGroups.value.length > 0
+)
+
+const filteredFiles = computed(() =>
+  filesForGroup(selectedGroup.value, {
+    files: files.value,
+    playlists: playlists.value,
+    artistGroups: artistGroups.value,
+    albumGroups: albumGroups.value,
+  })
+)
+
+const totalPages = computed(() =>
+  Math.ceil(filteredFiles.value.length / PAGE_SIZE)
+)
 
 const paginatedFiles = computed(() => {
   const start = (currentPage.value - 1) * PAGE_SIZE
-  return files.value.slice(start, start + PAGE_SIZE)
+  return filteredFiles.value.slice(start, start + PAGE_SIZE)
 })
 
-watch(files, () => {
+watch(filteredFiles, () => {
   currentPage.value = 1
 })
 
@@ -236,8 +335,13 @@ async function refresh() {
   loading.value = true
   error.value = ''
   try {
-    const res = await API.listDownloads()
-    files.value = res.data || []
+    const [tracksRes, playlistsRes] = await Promise.all([
+      API.listTracks(),
+      API.listPlaylists(),
+    ])
+    tracks.value = tracksRes.data || []
+    files.value = tracks.value.map((tr) => tr.file)
+    playlists.value = playlistsRes.data || []
   } catch {
     error.value = t('library.failedLoad')
   } finally {
@@ -251,6 +355,7 @@ async function onDelete(file) {
   try {
     await API.deleteDownload(file)
     files.value = files.value.filter((f) => f !== file)
+    tracks.value = tracks.value.filter((tr) => tr.file !== file)
   } catch {
     error.value = t('library.failedDelete', { file })
   } finally {
@@ -273,14 +378,15 @@ function folderOf(file) {
   return slash >= 0 ? file.slice(0, slash) : ''
 }
 
-function playFile(index) {
-  player.setPlaylist(files.value, { startIndex: index })
+function playFile(file) {
+  const index = filteredFiles.value.indexOf(file)
+  player.setPlaylist(filteredFiles.value, { startIndex: Math.max(0, index) })
   router.push({ name: 'Player' })
 }
 
 function playAll() {
-  if (!files.value.length) return
-  player.setPlaylist(files.value, { startIndex: 0 })
+  if (!filteredFiles.value.length) return
+  player.setPlaylist(filteredFiles.value, { startIndex: 0 })
   router.push({ name: 'Player' })
 }
 

--- a/frontend/src/views/Player.vue
+++ b/frontend/src/views/Player.vue
@@ -17,23 +17,56 @@
           </p>
         </div>
 
-        <div v-if="playlists.length > 0" class="shrink-0">
+        <div v-if="hasFilterableGroups" class="shrink-0">
           <label
             class="block text-xs font-semibold uppercase tracking-wider text-base-content/50 mb-1.5"
           >
             {{ t('player.playingFrom') }}
           </label>
           <select
-            v-model="selectedPlaylistName"
-            @change="onSelectPlaylist"
+            v-model="selectedGroup"
+            @change="onSelectGroup"
             class="select select-sm w-full sm:w-64 rounded-xl bg-base-100/85 border border-white/10 focus:border-primary/60"
           >
             <option :value="null">
               {{ t('player.allSongs', { count: files.length }) }}
             </option>
-            <option v-for="pl in playlists" :key="pl.name" :value="pl.name">
-              {{ pl.name }} ({{ pl.count }})
-            </option>
+            <optgroup
+              v-if="playlists.length > 0"
+              :label="t('player.playlistsGroup')"
+            >
+              <option
+                v-for="pl in playlists"
+                :key="'playlist-' + pl.name"
+                :value="{ type: 'playlist', name: pl.name }"
+              >
+                {{ pl.name }} ({{ pl.count }})
+              </option>
+            </optgroup>
+            <optgroup
+              v-if="artistGroups.length > 0"
+              :label="t('player.artistsGroup')"
+            >
+              <option
+                v-for="a in artistGroups"
+                :key="'artist-' + a.name"
+                :value="{ type: 'artist', name: a.name }"
+              >
+                {{ a.name }} ({{ a.count }})
+              </option>
+            </optgroup>
+            <optgroup
+              v-if="albumGroups.length > 0"
+              :label="t('player.albumsGroup')"
+            >
+              <option
+                v-for="al in albumGroups"
+                :key="'album-' + al.name"
+                :value="{ type: 'album', name: al.name }"
+              >
+                {{ al.name }} ({{ al.count }})
+              </option>
+            </optgroup>
           </select>
         </div>
       </div>
@@ -326,14 +359,21 @@ import Navbar from '/src/components/Navbar.vue'
 import Settings from '/src/components/Settings.vue'
 import API from '/src/model/api'
 import { usePlayer, formatTime } from '/src/model/player'
+import {
+  buildGroups,
+  filesForGroup as resolveFilesForGroup,
+  detectGroup,
+} from '/src/model/trackGroups'
 import { useI18n } from '/src/i18n'
 
 const { t } = useI18n()
 const player = usePlayer()
 
 const files = ref([])
+const tracks = ref([]) // [{ file, artist, album }] — from GET /tracks
 const playlists = ref([])
-const selectedPlaylistName = ref(null) // null = "All Songs"
+// null = "All Songs"; otherwise { type: 'playlist' | 'artist' | 'album', name }
+const selectedGroup = ref(null)
 const loading = ref(false)
 const progressBar = ref(null)
 const coverFailed = ref({})
@@ -343,10 +383,23 @@ function markCoverFailed(file) {
   coverFailed.value = { ...coverFailed.value, [file]: true }
 }
 
-function filesForSelection(name) {
-  if (!name) return files.value
-  const pl = playlists.value.find((p) => p.name === name)
-  return pl ? pl.files : files.value
+const artistGroups = computed(() => buildGroups(tracks.value, 'artist'))
+const albumGroups = computed(() => buildGroups(tracks.value, 'album'))
+
+const hasFilterableGroups = computed(
+  () =>
+    playlists.value.length > 0 ||
+    artistGroups.value.length > 0 ||
+    albumGroups.value.length > 0
+)
+
+function filesForGroup(group) {
+  return resolveFilesForGroup(group, {
+    files: files.value,
+    playlists: playlists.value,
+    artistGroups: artistGroups.value,
+    albumGroups: albumGroups.value,
+  })
 }
 
 // Reflect whichever queue is already loaded (playback survives
@@ -354,26 +407,22 @@ function filesForSelection(name) {
 // resetting it to "All Songs" on mount.
 function detectCurrentSelection() {
   const current = player.playlist.value.map((track) => track.file)
-  if (current.length === 0) {
-    selectedPlaylistName.value = null
-    return
-  }
-  const match = playlists.value.find(
-    (pl) =>
-      pl.files.length === current.length &&
-      pl.files.every((f, i) => f === current[i])
-  )
-  selectedPlaylistName.value = match ? match.name : null
+  selectedGroup.value = detectGroup(current, {
+    playlists: playlists.value,
+    artistGroups: artistGroups.value,
+    albumGroups: albumGroups.value,
+  })
 }
 
 async function load() {
   loading.value = true
   try {
-    const [libraryRes, playlistsRes] = await Promise.all([
-      API.listDownloads(),
+    const [tracksRes, playlistsRes] = await Promise.all([
+      API.listTracks(),
       API.listPlaylists(),
     ])
-    files.value = libraryRes.data || []
+    tracks.value = tracksRes.data || []
+    files.value = tracks.value.map((tr) => tr.file)
     playlists.value = playlistsRes.data || []
     // If the player was empty (direct nav to /player), seed the queue
     // with the full library so the user has something to play.
@@ -386,8 +435,8 @@ async function load() {
   }
 }
 
-function onSelectPlaylist() {
-  player.setPlaylist(filesForSelection(selectedPlaylistName.value))
+function onSelectGroup() {
+  player.setPlaylist(filesForGroup(selectedGroup.value))
 }
 
 const trackTitle = computed(() => {

--- a/main.py
+++ b/main.py
@@ -179,6 +179,28 @@ def _extract_cover(path: Path) -> tuple[bytes | None, str | None]:
     return None, None
 
 
+def _extract_track_tags(path: Path) -> tuple[str, str]:
+    """Return ``(artist, album)`` read from ``path``'s embedded tags.
+
+    Powers the player's "play only this artist/album" filters. Uses
+    mutagen's "easy" wrappers so ID3 (MP3), MP4 (M4A/AAC) and Vorbis
+    comments (FLAC/OGG/Opus) all expose the same ``artist``/``album``
+    keys without us needing to dispatch on extension. Missing or
+    unreadable tags come back as ``''`` — the frontend then buckets the
+    track the same way it already does for artist-less filenames.
+    """
+
+    try:
+        tags = MutagenFile(str(path), easy=True)
+    except Exception:
+        return '', ''
+    if not tags:
+        return '', ''
+    artist = (tags.get('artist') or [''])[0]
+    album = (tags.get('album') or [''])[0]
+    return artist, album
+
+
 def build_app() -> FastAPI:
     DOWNLOAD_DIR.mkdir(parents=True, exist_ok=True)
     DATABASE_DIR.mkdir(parents=True, exist_ok=True)
@@ -302,6 +324,35 @@ def build_app() -> FastAPI:
             })
         playlists.sort(key=lambda p: p['name'].casefold())
         return playlists
+
+    @app.get('/tracks')
+    def list_tracks() -> list[dict]:
+        """List downloaded tracks with artist/album read from embedded tags.
+
+        Powers the player's "play only this artist" / "play only this
+        album" filters (see the Vue Player view) — the flat ``/list``
+        endpoint only has filenames, and album in particular isn't
+        reliably derivable from the filename or folder layout unless
+        *Organize by artist/album* is on.
+        """
+        audio_exts = {'.mp3', '.m4a', '.flac', '.ogg', '.wav', '.aac', '.opus'}
+        base = DOWNLOAD_DIR.resolve()
+        if not base.exists():
+            return []
+        tracks: list[dict] = []
+        for path in base.rglob('*'):
+            if not path.is_file():
+                continue
+            if path.suffix.lower() not in audio_exts:
+                continue
+            artist, album = _extract_track_tags(path)
+            tracks.append({
+                'file': path.relative_to(base).as_posix(),
+                'artist': artist,
+                'album': album,
+            })
+        tracks.sort(key=lambda t: t['file'])
+        return tracks
 
     @app.delete('/delete')
     def delete_download(file: str) -> dict:

--- a/tests/test_main_tracks.py
+++ b/tests/test_main_tracks.py
@@ -1,0 +1,58 @@
+"""Tests for ``main._extract_track_tags``, which powers the player's
+"play only this artist" / "play only this album" filters (``GET
+/tracks``).
+
+The ``/tracks`` route itself lives inside ``main.build_app()`` alongside
+``/list``, ``/playlists``, ``/cover`` and ``/delete`` — none of which
+have route-level tests today (there's no TestClient/build_app fixture
+in this suite yet). ``_extract_track_tags`` is the actual new logic and
+is a plain module-level function, so it's tested directly here instead.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import main
+
+
+class _FakeEasyTags(dict):
+    """Mimics a mutagen "easy" wrapper: dict-like, list-valued fields."""
+
+
+def test_extract_track_tags_reads_artist_and_album(monkeypatch):
+    monkeypatch.setattr(
+        main,
+        'MutagenFile',
+        lambda *a, **kw: _FakeEasyTags(
+            artist=['Sleeping At Last'], album=['Atlas: Enneagram']
+        ),
+    )
+    artist, album = main._extract_track_tags(Path('song.mp3'))
+    assert artist == 'Sleeping At Last'
+    assert album == 'Atlas: Enneagram'
+
+
+def test_extract_track_tags_missing_fields_are_empty(monkeypatch):
+    monkeypatch.setattr(main, 'MutagenFile', lambda *a, **kw: _FakeEasyTags())
+    artist, album = main._extract_track_tags(Path('song.mp3'))
+    assert not artist
+    assert not album
+
+
+def test_extract_track_tags_no_tags_object(monkeypatch):
+    # e.g. a file mutagen can't identify at all.
+    monkeypatch.setattr(main, 'MutagenFile', lambda *a, **kw: None)
+    artist, album = main._extract_track_tags(Path('song.mp3'))
+    assert not artist
+    assert not album
+
+
+def test_extract_track_tags_unreadable_file_does_not_raise(monkeypatch):
+    def _raise(*a, **kw):
+        raise OSError('corrupt file')
+
+    monkeypatch.setattr(main, 'MutagenFile', _raise)
+    artist, album = main._extract_track_tags(Path('song.mp3'))
+    assert not artist
+    assert not album


### PR DESCRIPTION
Extends the "play only this playlist/artist/album" filter added to the Player onto the Library page, so browsing/deleting/re-downloading can also be narrowed to one playlist, artist, or album instead of scrolling the whole flat file list.

- `frontend/src/model/trackGroups.js` (new): the artist/album bucketing and group-selector-value resolution logic, extracted out of `Player.vue` so both pages share one implementation instead of duplicating it. `Player.vue` now imports from here — no behavior change there.
- `frontend/src/views/Downloads.vue`: adds the same Playlists/Artists/ Albums "Filter by" selector as the player (built from the existing `GET /tracks` + `GET /playlists`). The paginated list, count footer, "Play" / "Play all" and the empty state now all respect the active filter; a distinct empty state ("no files match this filter" + clear-filter button) covers the case where the library has files but none match the current filter. Deleting a file also drops it from the in-memory tag list so its artist/album group updates immediately.
- i18n: `library.filterBy` / `filterEmpty` / `clearFilter` added to all 8 locales (reusing the already-translated `player.allSongs` / `playlistsGroup` / `artistsGroup` / `albumsGroup` keys for the shared option labels).
- Docs: `docs/features/player.md`, `docs/api-reference.md` and `README.md` updated to mention the Library page now has the same filter (and fixed a stale anchor link after the player doc's heading changed in the previous player-filtering change).

No backend changes — reuses the `/tracks` and `/playlists` endpoints added for the player filter.

close #277