### PR TITLE
fix(monitor): trust the downloaded-tracks DB, not the filesystem

### DIFF
--- a/docs/features/playlist-monitor.md
+++ b/docs/features/playlist-monitor.md
@@ -26,7 +26,9 @@ Downtify keeps a background task running every 60 seconds. On each sweep it chec
 3. Downloads any new tracks using the same pipeline as a manual download
 4. Updates the M3U file for the playlist (if M3U generation is enabled)
 
-Tracks that were already in the playlist when you added it are skipped — only *new* additions are downloaded. If a track's file is later deleted from disk, it will be re-downloaded on the next check.
+Tracks that were already in the playlist when you added it are skipped — only *new* additions are downloaded. "Already downloaded" is tracked in a small SQLite database (`downtify_monitor.db` under `/data`), not by checking the downloads folder — so moving a downloaded file elsewhere on disk (into your own library layout, another drive, wherever) does **not** make Downtify think it's missing and re-download it on the next check.
+
+A separate sweep runs every hour and checks whether each downloaded track's file is still there. Genuinely deleted files (as opposed to ones you moved) are forgotten at that point, so the track becomes eligible for download again — on the next watch check after that hourly sweep, not instantly.
 
 A watch is never checked twice at the same time. Adding a watch starts its first check immediately; if that check is still downloading when the next scheduled sweep comes around, the sweep skips the watch instead of starting a second, overlapping download of the same tracks.
 

--- a/downtify/monitor.py
+++ b/downtify/monitor.py
@@ -16,6 +16,8 @@ from . import m3u, providers, spotify
 from .downloader import Downloader
 
 MONITOR_LOOP_INTERVAL = 60  # seconds between loop sweeps
+# Seconds between filesystem reconciliation sweeps (see reconcile_loop).
+RECONCILE_LOOP_INTERVAL = 3600
 MINUTES_PER_DAY = 1440
 
 SYNC_TIME_ENV_VAR = 'DOWNTIFY_MONITOR_SYNC_TIME'
@@ -351,6 +353,41 @@ class PlaylistMonitorDB:
                 (playlist_id, track_spotify_id, _now_iso(), filename),
             )
 
+    def list_all_downloaded_tracks(self) -> list[dict[str, Any]]:
+        """Every ``downloaded_tracks`` row that has a filename, across
+        every watch.
+
+        Used by the hourly reconciliation sweep (see
+        :func:`reconcile_downloaded_tracks`), which checks all of them
+        against the filesystem in one pass instead of one watch at a
+        time.
+        """
+        with self._connect() as conn:
+            rows = conn.execute(
+                """SELECT playlist_id, track_spotify_id, filename
+                   FROM downloaded_tracks
+                   WHERE filename IS NOT NULL"""
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+    def remove_downloaded_tracks(self, pairs: list[tuple[int, str]]) -> int:
+        """Delete the given ``(playlist_id, track_spotify_id)`` rows.
+
+        Called when the hourly reconciliation sweep finds a downloaded
+        track's file is no longer under the downloads directory — the
+        track goes back to being "not downloaded" and is re-fetched on
+        the watch's next check.
+        """
+        if not pairs:
+            return 0
+        with self._connect() as conn:
+            conn.executemany(
+                """DELETE FROM downloaded_tracks
+                   WHERE playlist_id = ? AND track_spotify_id = ?""",
+                pairs,
+            )
+        return len(pairs)
+
 
 def _row_to_playlist(row: sqlite3.Row) -> MonitoredPlaylist:
     keys = row.keys()
@@ -427,11 +464,20 @@ async def check_playlist(
 
     pl_subdir = m3u.sanitize_playlist_name(playlist.name)
 
-    # Filenames already on disk from earlier sweeps, keyed by track id,
+    # Filenames already known from earlier sweeps, keyed by track id,
     # topped up as each new track lands. Lets the M3U be rewritten after
     # every single download without re-resolving the whole playlist
     # against the filesystem each time (which is O(tracks) globs per
     # write, and quadratic over a large sweep).
+    #
+    # A track already in `downloaded_tracks` is trusted as downloaded
+    # without checking whether its file is still on disk — the file may
+    # have been moved elsewhere in the filesystem outside the downloads
+    # directory (e.g. into a separate media library), which must not
+    # cause a re-download on every single sweep. A file that's actually
+    # gone (deleted, not just moved) is instead noticed and forgotten by
+    # the hourly :func:`reconcile_downloaded_tracks` sweep, which is what
+    # makes such a track eligible for re-download again.
     resolved: dict[str, str] = {}
 
     new_tracks = []
@@ -443,12 +489,7 @@ async def check_playlist(
             new_tracks.append(t)
         else:
             stored = known_tracks[tid]
-            if stored is None:
-                continue
-            if not (downloader.download_dir / stored).exists():
-                # File was deleted — re-download
-                new_tracks.append(t)
-            else:
+            if stored is not None:
                 resolved[tid] = stored
 
     if new_tracks:
@@ -775,3 +816,56 @@ async def monitor_loop(
         except Exception:
             logger.exception('Unexpected error in monitor loop')
         await asyncio.sleep(MONITOR_LOOP_INTERVAL)
+
+
+async def reconcile_downloaded_tracks(
+    db: PlaylistMonitorDB, downloader: Downloader
+) -> int:
+    """Drop ``downloaded_tracks`` rows whose file is gone from disk.
+
+    ``check_playlist`` trusts a row in ``downloaded_tracks`` as proof a
+    track was already downloaded without re-checking the filesystem (see
+    its docstring) — otherwise a file moved elsewhere on disk would be
+    re-downloaded on every single sweep. This is the other half of that
+    trade-off: a track whose file has genuinely disappeared (deleted,
+    not just moved) is still noticed here and forgotten, so it becomes
+    eligible for re-download again on the watch's next check. Returns
+    the number of rows removed.
+    """
+    rows = await asyncio.to_thread(db.list_all_downloaded_tracks)
+    missing = [
+        (row['playlist_id'], row['track_spotify_id'])
+        for row in rows
+        if not (downloader.download_dir / row['filename']).exists()
+    ]
+    if missing:
+        await asyncio.to_thread(db.remove_downloaded_tracks, missing)
+    return len(missing)
+
+
+async def reconcile_loop(
+    db: PlaylistMonitorDB,
+    get_downloader: Callable[[], Optional[Downloader]],
+    interval_seconds: int = RECONCILE_LOOP_INTERVAL,
+) -> None:
+    """Background task: hourly, prune downloaded-track records for files
+    that are no longer in the downloads directory.
+
+    Runs independently of :func:`monitor_loop` and its per-watch
+    schedule — this sweep always checks every known downloaded track
+    across every watch, on its own fixed cadence.
+    """
+    while True:
+        try:
+            downloader = get_downloader()
+            if downloader is not None:
+                removed = await reconcile_downloaded_tracks(db, downloader)
+                if removed:
+                    logger.info(
+                        '{} downloaded-track record(s) removed: file no '
+                        'longer found in the downloads directory',
+                        removed,
+                    )
+        except Exception:
+            logger.exception('Unexpected error in reconcile loop')
+        await asyncio.sleep(interval_seconds)

--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ from uvicorn import Config, Server
 
 from downtify import __version__, api, m3u
 from downtify.downloader import Downloader
-from downtify.monitor import PlaylistMonitorDB, monitor_loop
+from downtify.monitor import PlaylistMonitorDB, monitor_loop, reconcile_loop
 
 load_dotenv()
 
@@ -274,6 +274,16 @@ def build_app() -> FastAPI:
                 broadcast=api.state.connections.broadcast,
                 loop=loop,
                 settings=api.state.settings,
+            )
+        )
+        # Separate hourly sweep that forgets a downloaded-track record once
+        # its file is gone from the downloads directory — see
+        # downtify/monitor.py:reconcile_loop for why this is a distinct,
+        # slower cadence from the per-watch monitor_loop above.
+        asyncio.create_task(
+            reconcile_loop(
+                db=api.state.monitor_db,
+                get_downloader=lambda: api.state.downloader,
             )
         )
 

--- a/tests/test_monitor_track_reconciliation.py
+++ b/tests/test_monitor_track_reconciliation.py
@@ -1,0 +1,240 @@
+"""Tests for the "trust the DB, not the filesystem" Playlist Monitor
+dedup fix (downtify/monitor.py):
+
+* ``check_playlist`` must not re-download a track it already recorded
+  in ``downloaded_tracks`` just because its file isn't at the stored
+  path anymore (e.g. the user moved it elsewhere on disk).
+* A separate hourly sweep (``reconcile_downloaded_tracks`` /
+  ``reconcile_loop``) is what still notices a track whose file is
+  genuinely gone and forgets it, making it eligible for re-download.
+
+All offline — uses a real (tmp_path) ``PlaylistMonitorDB`` plus a fake
+downloader, no network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from downtify import monitor
+
+
+class _FakeDownloader:
+    organize_by_artist = False
+    organize_by_album = False
+
+    def __init__(self, tmp_path, *, fail=False):
+        self.download_dir = tmp_path
+        self.fail = fail
+        self.calls: list[str] = []
+
+    def download(self, song, progress_cb=None, subdir=None):
+        if self.fail:
+            raise RuntimeError('should not be called')
+        self.calls.append(song['song_id'])
+        return f'{song["song_id"]}.mp3'
+
+
+def _db(tmp_path) -> monitor.PlaylistMonitorDB:
+    return monitor.PlaylistMonitorDB(tmp_path / 'monitor.db')
+
+
+async def _noop_broadcast(_msg):
+    return None
+
+
+def _playlist(tmp_path):
+    db = _db(tmp_path)
+    pl = db.add_playlist('pl1', 'My Playlist', 'url', 60)
+    return db, pl
+
+
+# ── check_playlist trusts the DB over the filesystem ─────────────────────────
+
+
+def test_check_playlist_does_not_redownload_when_file_moved_away(
+    monkeypatch, tmp_path
+):
+    db, pl = _playlist(tmp_path)
+    # Recorded as downloaded in an earlier sweep, but the file is no
+    # longer under the downloads directory (moved elsewhere on disk).
+    db.mark_track_downloaded(pl.id, 'a', 'a.mp3')
+
+    tracks = [{'song_id': 'a', 'name': 'A', 'artists': ['Artist']}]
+    monkeypatch.setattr(
+        monitor.spotify, 'playlist_tracks_from_id', lambda spotify_id: tracks
+    )
+    monkeypatch.setattr(monitor.spotify, 'track_from_id', lambda tid: {})
+
+    downloader = _FakeDownloader(tmp_path, fail=True)
+
+    async def _scenario():
+        return await monitor.check_playlist(
+            pl,
+            db,
+            downloader,
+            _noop_broadcast,
+            asyncio.get_running_loop(),
+            settings={'generate_m3u': False},
+        )
+
+    downloaded = asyncio.run(_scenario())
+
+    assert downloaded == 0
+    assert downloader.calls == []
+
+
+def test_check_playlist_still_downloads_genuinely_new_tracks(
+    monkeypatch, tmp_path
+):
+    db, pl = _playlist(tmp_path)
+    db.mark_track_downloaded(pl.id, 'a', 'a.mp3')  # known, file missing
+
+    tracks = [
+        {'song_id': 'a', 'name': 'A', 'artists': ['Artist']},
+        {'song_id': 'b', 'name': 'B', 'artists': ['Artist']},
+    ]
+    monkeypatch.setattr(
+        monitor.spotify, 'playlist_tracks_from_id', lambda spotify_id: tracks
+    )
+    monkeypatch.setattr(monitor.spotify, 'track_from_id', lambda tid: {})
+
+    downloader = _FakeDownloader(tmp_path)
+
+    async def _scenario():
+        return await monitor.check_playlist(
+            pl,
+            db,
+            downloader,
+            _noop_broadcast,
+            asyncio.get_running_loop(),
+            settings={'generate_m3u': False},
+        )
+
+    downloaded = asyncio.run(_scenario())
+
+    assert downloaded == 1
+    assert downloader.calls == ['b']
+
+
+# ── PlaylistMonitorDB: list/remove downloaded tracks ─────────────────────────
+
+
+def test_list_all_downloaded_tracks_only_returns_rows_with_a_filename(
+    tmp_path,
+):
+    db, pl = _playlist(tmp_path)
+    db.mark_track_downloaded(pl.id, 'a', 'a.mp3')
+    db.mark_track_downloaded(pl.id, 'b', None)
+
+    rows = db.list_all_downloaded_tracks()
+
+    assert rows == [
+        {'playlist_id': pl.id, 'track_spotify_id': 'a', 'filename': 'a.mp3'}
+    ]
+
+
+def test_remove_downloaded_tracks_deletes_only_given_pairs(tmp_path):
+    db, pl = _playlist(tmp_path)
+    db.mark_track_downloaded(pl.id, 'a', 'a.mp3')
+    db.mark_track_downloaded(pl.id, 'b', 'b.mp3')
+
+    removed = db.remove_downloaded_tracks([(pl.id, 'a')])
+
+    assert removed == 1
+    remaining = db.get_track_filenames(pl.id)
+    assert remaining == {'b': 'b.mp3'}
+
+
+def test_remove_downloaded_tracks_no_op_for_empty_list(tmp_path):
+    db, pl = _playlist(tmp_path)
+    db.mark_track_downloaded(pl.id, 'a', 'a.mp3')
+
+    assert db.remove_downloaded_tracks([]) == 0
+    assert db.get_track_filenames(pl.id) == {'a': 'a.mp3'}
+
+
+# ── reconcile_downloaded_tracks ──────────────────────────────────────────────
+
+
+def test_reconcile_removes_rows_whose_file_is_gone(tmp_path):
+    db, pl = _playlist(tmp_path)
+    (tmp_path / 'present.mp3').write_bytes(b'')
+    db.mark_track_downloaded(pl.id, 'present', 'present.mp3')
+    db.mark_track_downloaded(pl.id, 'missing', 'missing.mp3')
+
+    downloader = _FakeDownloader(tmp_path)
+    removed = asyncio.run(monitor.reconcile_downloaded_tracks(db, downloader))
+
+    assert removed == 1
+    assert db.get_track_filenames(pl.id) == {'present': 'present.mp3'}
+
+
+def test_reconcile_is_a_no_op_when_all_files_present(tmp_path):
+    db, pl = _playlist(tmp_path)
+    (tmp_path / 'a.mp3').write_bytes(b'')
+    db.mark_track_downloaded(pl.id, 'a', 'a.mp3')
+
+    downloader = _FakeDownloader(tmp_path)
+    removed = asyncio.run(monitor.reconcile_downloaded_tracks(db, downloader))
+
+    assert removed == 0
+    assert db.get_track_filenames(pl.id) == {'a': 'a.mp3'}
+
+
+# ── reconcile_loop ────────────────────────────────────────────────────────────
+
+
+class _Stop(Exception):
+    pass
+
+
+def test_reconcile_loop_sweeps_then_sleeps_the_configured_interval(
+    monkeypatch, tmp_path
+):
+    db, pl = _playlist(tmp_path)
+    db.mark_track_downloaded(pl.id, 'missing', 'missing.mp3')
+    downloader = _FakeDownloader(tmp_path)
+
+    sleeps: list[float] = []
+
+    async def _stop(seconds):
+        sleeps.append(seconds)
+        raise _Stop
+
+    monkeypatch.setattr(monitor.asyncio, 'sleep', _stop)
+
+    async def _scenario():
+        try:
+            await monitor.reconcile_loop(
+                db, lambda: downloader, interval_seconds=123
+            )
+        except _Stop:
+            pass
+
+    asyncio.run(_scenario())
+
+    assert sleeps == [123]
+    # The one missing-file row was pruned during the sweep before sleeping.
+    assert db.get_track_filenames(pl.id) == {}
+
+
+def test_reconcile_loop_tolerates_no_downloader_yet(monkeypatch, tmp_path):
+    db, pl = _playlist(tmp_path)
+    db.mark_track_downloaded(pl.id, 'a', 'a.mp3')
+
+    async def _stop(_seconds):
+        raise _Stop
+
+    monkeypatch.setattr(monitor.asyncio, 'sleep', _stop)
+
+    async def _scenario():
+        try:
+            await monitor.reconcile_loop(db, lambda: None)
+        except _Stop:
+            pass
+
+    asyncio.run(_scenario())  # must not raise
+
+    # No downloader available yet -> nothing was reconciled.
+    assert db.get_track_filenames(pl.id) == {'a': 'a.mp3'}


### PR DESCRIPTION
Playlist Monitor already recorded every auto-downloaded track in the `downloaded_tracks` SQLite table (`/data/downtify_monitor.db`), but `check_playlist` still re-checked the filesystem before trusting it: a known track whose file wasn't at its stored path anymore was treated as deleted and re-downloaded. That meant simply moving a downloaded file elsewhere on disk (into your own library layout, another drive, a media server's folder structure, ...) made the Monitor re-download it on every single check.

- `downtify/monitor.py:check_playlist` — a track already present in `downloaded_tracks` is now trusted as downloaded unconditionally; the per-track `(download_dir / stored).exists()` check and its re-download branch are gone. (`check_artist` already worked this way and needed no change.)
- New hourly sweep, independent of each watch's own check interval:
  - `PlaylistMonitorDB.list_all_downloaded_tracks()` / `.remove_downloaded_tracks(pairs)` — read/prune `downloaded_tracks` rows across every watch at once.
  - `monitor.reconcile_downloaded_tracks(db, downloader)` — checks every known track's file against the downloads directory and drops the DB row for any that's actually gone (as opposed to merely moved), so that track becomes eligible for re-download on the watch's next check.
  - `monitor.reconcile_loop(db, get_downloader, interval_seconds=3600)` — runs the sweep once immediately and then every hour.
  - Wired up in `main.py`'s startup hook alongside the existing `monitor_loop` task.
- No schema change and no new database file — the existing `downloaded_tracks` table already lived at `/data/downtify_monitor.db`, which is what the original feature request asked for.
- `docs/features/playlist-monitor.md` updated: replaced the stale "a deleted file is re-downloaded on the next check" line with how the DB-first check plus the hourly reconciliation sweep actually behave now.
- Tests: `tests/test_monitor_track_reconciliation.py` (9 new tests) — `check_playlist` no longer re-downloads a known track with a missing file but still downloads genuinely new ones; the new DB methods; `reconcile_downloaded_tracks` pruning only rows whose file is gone; `reconcile_loop`'s sweep-then-sleep cadence and its no-downloader-yet guard.

close #283