### PR TITLE
fix(library): clean up sidecars and empty folders when deleting a track

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -317,7 +317,11 @@ Sorted by `file`, same order as `/list`. `artist`/`album` come back as `""` when
 
 ### `DELETE /delete`
 
-Delete a downloaded file.
+Delete a downloaded file, plus its leftovers — best-effort, so a missing or unremovable one doesn't fail the request:
+
+- its `.lrc` lyrics sidecar, if any (same basename, see [Lyrics](features/lyrics.md));
+- the folder's shared `cover.jpg` under [*Organize by album*](features/download-settings.md#download-cover-art), but only once no other track in that same folder still needs it;
+- the file's folder, and any of its ancestors, that end up empty as a result — climbing up but never past the downloads directory root.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/docs/features/download-settings.md
+++ b/docs/features/download-settings.md
@@ -87,6 +87,8 @@ Controls whether Downtify embeds album art at all. On by default. Turn it off to
 
 Turning this off also skips writing the standalone `cover.jpg` that the *Organize by album* option (see [File Organization](file-organization.md)) produces, and the [player](player.md)/library will show no artwork for tracks downloaded this way (the fallback music-note icon instead).
 
+That `cover.jpg` is shared by every track in the album folder. Deleting a track from the Library page removes it too, but only once it's the **last** track left in that folder — as long as another track from the same album is still there, the cover stays.
+
 ## Cover art resolution
 
 Only relevant when **Download cover art** (above) is on. Sets the target size (width and height, in pixels) Downtify requests for embedded cover art sourced from **YouTube Music**. Pick a preset (300, 600, 800, 1000, 1200) or drag the slider anywhere from **300 to 1200**; the current value in pixels is shown next to it. Default is 600.

--- a/docs/features/file-organization.md
+++ b/docs/features/file-organization.md
@@ -43,3 +43,7 @@ When *Organize by artist* is on and you download a Spotify playlist with M3U gen
 ## Changing the setting
 
 The setting takes effect immediately for all **new** downloads. Existing files already on disk are not moved.
+
+## Deleting a track cleans up empty folders
+
+Deleting a track from the Library page removes its per-playlist, artist or album folder too, once it's empty — and keeps climbing up through any now-empty parent folders (e.g. the artist folder after its last album is gone), stopping at the downloads directory itself, which is never removed. A folder that still holds anything else — another track, an `.m3u`, a `cover.jpg` still in use — is left alone.

--- a/docs/features/lyrics.md
+++ b/docs/features/lyrics.md
@@ -32,6 +32,8 @@ lrclib is queried with the track title, primary artist, album name and duration.
 
 When synced lyrics are available, Downtify also saves a `.lrc` file next to the audio file with the same base name. This lets media players that support external lyrics files (like Jellyfin or certain portable players) show the time-synced lyrics independently of the embedded tags.
 
+Deleting the track from the Library page removes this `.lrc` sidecar along with the audio file, so lyrics never linger as an orphaned file.
+
 ## Fallback behaviour
 
 If lrclib returns no result for a track, the download continues normally — the audio file is saved without lyrics. No error is raised.

--- a/main.py
+++ b/main.py
@@ -87,6 +87,12 @@ WEB_GUI_LOCATION = os.getenv('WEB_GUI_LOCATION', '/downtify/frontend/dist')
 DEFAULT_HOST = os.getenv('HOST', '0.0.0.0')
 DEFAULT_PORT = int(os.getenv('DOWNTIFY_PORT', os.getenv('PORT', '8000')))
 
+_AUDIO_EXTENSIONS = {'.mp3', '.m4a', '.flac', '.ogg', '.wav', '.aac', '.opus'}
+
+#: Filename written by Downloader._save_album_cover next to every track
+#: of an album folder (organize-by-album layout only).
+_ALBUM_COVER_FILENAME = 'cover.jpg'
+
 
 class SPAStaticFiles(StaticFiles):
     """Serve ``index.html`` for unknown paths so SPA routing works."""
@@ -202,6 +208,78 @@ def _extract_track_tags(path: Path) -> tuple[str, str]:
     return artist, album
 
 
+def _delete_lrc_sidecar(audio_path: Path) -> None:
+    """Best-effort removal of the .lrc sidecar next to a deleted track.
+
+    Mirrors the naming ``downtify/downloader.py:embed_lyrics`` writes the
+    sidecar with — same basename as the audio file, ``.lrc`` extension.
+    A missing or unremovable sidecar must not fail the audio file's own
+    deletion, which has already succeeded by the time this runs.
+    """
+    lrc = audio_path.with_suffix('.lrc')
+    try:
+        lrc.unlink(missing_ok=True)
+    except OSError:
+        logger.opt(exception=True).warning(
+            'Could not remove LRC sidecar {}', lrc
+        )
+
+
+def _delete_album_cover_if_orphaned(audio_path: Path) -> None:
+    """Best-effort removal of a now-unused ``cover.jpg``.
+
+    ``cover.jpg`` (written by ``Downloader._save_album_cover`` under the
+    *Organize by album* layout) sits once per album folder, shared by
+    every track in it — so it's only safe to delete once no other track
+    in that same folder still needs it. Checked *after* the audio file
+    itself is gone, so the deleted track doesn't count as a remaining
+    dependent.
+    """
+    folder = audio_path.parent
+    cover = folder / _ALBUM_COVER_FILENAME
+    if not cover.is_file():
+        return
+    still_used = any(
+        p.is_file() and p.suffix.lower() in _AUDIO_EXTENSIONS
+        for p in folder.iterdir()
+    )
+    if still_used:
+        return
+    try:
+        cover.unlink(missing_ok=True)
+    except OSError:
+        logger.opt(exception=True).warning(
+            'Could not remove orphaned album cover {}', cover
+        )
+
+
+def _prune_empty_parent_dirs(start_dir: Path, root: Path) -> None:
+    """Remove ``start_dir`` and its empty ancestors, stopping at ``root``.
+
+    Run after a track and its sidecars are deleted, so a per-playlist or
+    per-artist/album folder left with nothing in it doesn't linger
+    forever. Climbs one directory at a time and stops at the first one
+    that still has something in it — ``root`` (the downloads directory)
+    is never removed itself, even if it ends up empty.
+    """
+    try:
+        root = root.resolve()
+        current = start_dir.resolve()
+    except OSError:
+        return
+    # Safety: only ever climb within root's own tree, never above it.
+    if current != root and root not in current.parents:
+        return
+    while current != root:
+        try:
+            if any(current.iterdir()):
+                return
+            current.rmdir()
+        except OSError:
+            return
+        current = current.parent
+
+
 def build_app() -> FastAPI:
     DOWNLOAD_DIR.mkdir(parents=True, exist_ok=True)
     DATABASE_DIR.mkdir(parents=True, exist_ok=True)
@@ -296,7 +374,6 @@ def build_app() -> FastAPI:
 
     @app.get('/list')
     def list_downloads() -> list[str]:
-        audio_exts = {'.mp3', '.m4a', '.flac', '.ogg', '.wav', '.aac', '.opus'}
         base = DOWNLOAD_DIR.resolve()
         if not base.exists():
             return []
@@ -306,7 +383,7 @@ def build_app() -> FastAPI:
         for path in base.rglob('*'):
             if not path.is_file():
                 continue
-            if path.suffix.lower() not in audio_exts:
+            if path.suffix.lower() not in _AUDIO_EXTENSIONS:
                 continue
             files.append(path.relative_to(base).as_posix())
         files.sort()
@@ -352,7 +429,6 @@ def build_app() -> FastAPI:
         reliably derivable from the filename or folder layout unless
         *Organize by artist/album* is on.
         """
-        audio_exts = {'.mp3', '.m4a', '.flac', '.ogg', '.wav', '.aac', '.opus'}
         base = DOWNLOAD_DIR.resolve()
         if not base.exists():
             return []
@@ -360,7 +436,7 @@ def build_app() -> FastAPI:
         for path in base.rglob('*'):
             if not path.is_file():
                 continue
-            if path.suffix.lower() not in audio_exts:
+            if path.suffix.lower() not in _AUDIO_EXTENSIONS:
                 continue
             artist, album = _extract_track_tags(path)
             tracks.append({
@@ -386,6 +462,9 @@ def build_app() -> FastAPI:
             full.unlink()
         except Exception as exc:
             return {'deleted': False, 'error': str(exc)}
+        _delete_lrc_sidecar(full)
+        _delete_album_cover_if_orphaned(full)
+        _prune_empty_parent_dirs(full.parent, base)
         return {'deleted': True}
 
     @app.get('/cover')

--- a/tests/test_delete_sidecars.py
+++ b/tests/test_delete_sidecars.py
@@ -1,0 +1,253 @@
+"""Tests for the cleanup ``DELETE /delete`` does after removing a track:
+``main._delete_lrc_sidecar``, ``main._delete_album_cover_if_orphaned``
+and ``main._prune_empty_parent_dirs``.
+
+Deleting a track through the Library page used to only remove the audio
+file, leaving things behind:
+
+* the ``.lrc`` lyrics sidecar (see ``downtify/downloader.py:embed_lyrics``),
+  sharing the audio file's basename;
+* under *Organize by album*, the album's shared ``cover.jpg`` (see
+  ``Downloader._save_album_cover``) — but only once no other track in
+  that same folder still needs it;
+* the (now possibly empty) per-playlist/artist/album folder itself, and
+  any of its ancestors that are also now empty, up to but not including
+  the downloads directory root.
+
+``DELETE /delete`` itself lives inside ``main.build_app()`` alongside
+the other file-management routes, none of which have route-level tests
+in this suite (no TestClient/build_app fixture yet — see
+test_main_tracks.py). All three cleanup functions are plain
+module-level functions, so they're tested directly here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import main
+
+# ── _delete_lrc_sidecar ──────────────────────────────────────────────────────
+
+
+def test_delete_lrc_sidecar_removes_matching_lrc(tmp_path):
+    audio = tmp_path / 'Artist - Song.mp3'
+    audio.write_bytes(b'audio')
+    lrc = tmp_path / 'Artist - Song.lrc'
+    lrc.write_text('[00:00.00]La la la', encoding='utf-8')
+
+    main._delete_lrc_sidecar(audio)
+
+    assert not lrc.exists()
+
+
+def test_delete_lrc_sidecar_no_op_when_no_lyrics(tmp_path):
+    audio = tmp_path / 'Artist - Song.mp3'
+    audio.write_bytes(b'audio')
+
+    # Must not raise just because there was never a .lrc to begin with.
+    main._delete_lrc_sidecar(audio)
+
+
+def test_delete_lrc_sidecar_does_not_touch_other_files(tmp_path):
+    audio = tmp_path / 'Artist - Song.mp3'
+    audio.write_bytes(b'audio')
+    other_lrc = tmp_path / 'Other Song.lrc'
+    other_lrc.write_text('unrelated', encoding='utf-8')
+
+    main._delete_lrc_sidecar(audio)
+
+    assert other_lrc.exists()
+
+
+def test_delete_lrc_sidecar_survives_unremovable_file(tmp_path, monkeypatch):
+    audio = tmp_path / 'Artist - Song.mp3'
+    audio.write_bytes(b'audio')
+    lrc = tmp_path / 'Artist - Song.lrc'
+    lrc.write_text('lyrics', encoding='utf-8')
+
+    def _raise(*_a, **_kw):
+        raise OSError('permission denied')
+
+    monkeypatch.setattr(Path, 'unlink', _raise)
+
+    # Must not propagate — the audio file's own deletion already
+    # succeeded by the time this runs.
+    main._delete_lrc_sidecar(audio)
+
+
+# ── _delete_album_cover_if_orphaned ──────────────────────────────────────────
+
+
+def _album_folder(tmp_path, *track_names: str) -> Path:
+    folder = tmp_path / 'Some Album'
+    folder.mkdir()
+    for name in track_names:
+        (folder / name).write_bytes(b'audio')
+    return folder
+
+
+def test_cover_deleted_when_last_track_in_folder_is_gone(tmp_path):
+    folder = _album_folder(tmp_path, 'Track 1.mp3')
+    cover = folder / 'cover.jpg'
+    cover.write_bytes(b'jpeg data')
+    deleted_track = folder / 'Track 1.mp3'
+
+    # Mirrors what delete_download does: audio file is unlinked first...
+    deleted_track.unlink()
+    # ...then cleanup runs.
+    main._delete_album_cover_if_orphaned(deleted_track)
+
+    assert not cover.exists()
+
+
+def test_cover_kept_when_another_track_remains(tmp_path):
+    folder = _album_folder(tmp_path, 'Track 1.mp3', 'Track 2.mp3')
+    cover = folder / 'cover.jpg'
+    cover.write_bytes(b'jpeg data')
+    deleted_track = folder / 'Track 1.mp3'
+
+    deleted_track.unlink()
+    main._delete_album_cover_if_orphaned(deleted_track)
+
+    assert cover.exists()
+    assert (folder / 'Track 2.mp3').exists()
+
+
+def test_cover_kept_when_a_different_audio_extension_remains(tmp_path):
+    # A FLAC re-download of the same track counts as "still needs it".
+    folder = _album_folder(tmp_path, 'Track 1.mp3', 'Track 1.flac')
+    cover = folder / 'cover.jpg'
+    cover.write_bytes(b'jpeg data')
+    deleted_track = folder / 'Track 1.mp3'
+
+    deleted_track.unlink()
+    main._delete_album_cover_if_orphaned(deleted_track)
+
+    assert cover.exists()
+
+
+def test_no_op_when_there_is_no_cover(tmp_path):
+    folder = _album_folder(tmp_path, 'Track 1.mp3')
+    deleted_track = folder / 'Track 1.mp3'
+    deleted_track.unlink()
+
+    # Must not raise just because organize-by-album was never on.
+    main._delete_album_cover_if_orphaned(deleted_track)
+
+
+def test_cover_ignores_lrc_and_m3u_siblings(tmp_path):
+    # A leftover .lrc or .m3u must not count as a reason to keep the cover.
+    folder = _album_folder(tmp_path, 'Track 1.mp3')
+    cover = folder / 'cover.jpg'
+    cover.write_bytes(b'jpeg data')
+    (folder / 'Track 1.lrc').write_text('lyrics', encoding='utf-8')
+    (folder / 'Some Album.m3u').write_text('#EXTM3U\n', encoding='utf-8')
+    deleted_track = folder / 'Track 1.mp3'
+
+    deleted_track.unlink()
+    main._delete_album_cover_if_orphaned(deleted_track)
+
+    assert not cover.exists()
+
+
+def test_cover_survives_unremovable_file(tmp_path, monkeypatch):
+    folder = _album_folder(tmp_path, 'Track 1.mp3')
+    cover = folder / 'cover.jpg'
+    cover.write_bytes(b'jpeg data')
+    deleted_track = folder / 'Track 1.mp3'
+    deleted_track.unlink()
+
+    def _raise(*_a, **_kw):
+        raise OSError('permission denied')
+
+    monkeypatch.setattr(Path, 'unlink', _raise)
+
+    # Must not propagate.
+    main._delete_album_cover_if_orphaned(deleted_track)
+
+
+# ── _prune_empty_parent_dirs ─────────────────────────────────────────────────
+
+
+def test_prune_removes_single_empty_folder(tmp_path):
+    root = tmp_path
+    playlist_dir = root / 'My Playlist'
+    playlist_dir.mkdir()
+
+    main._prune_empty_parent_dirs(playlist_dir, root)
+
+    assert not playlist_dir.exists()
+    assert root.exists()
+
+
+def test_prune_climbs_nested_empty_folders_up_to_root(tmp_path):
+    root = tmp_path
+    album_dir = root / 'Some Artist' / 'Some Album'
+    album_dir.mkdir(parents=True)
+
+    main._prune_empty_parent_dirs(album_dir, root)
+
+    assert not album_dir.exists()
+    assert not (root / 'Some Artist').exists()
+    assert root.exists()
+
+
+def test_prune_stops_at_first_non_empty_ancestor(tmp_path):
+    root = tmp_path
+    artist_dir = root / 'Some Artist'
+    album_dir = artist_dir / 'Album A'
+    other_album_dir = artist_dir / 'Album B'
+    album_dir.mkdir(parents=True)
+    other_album_dir.mkdir(parents=True)
+
+    main._prune_empty_parent_dirs(album_dir, root)
+
+    # Album A is gone, but Artist still holds Album B, so it must stay.
+    assert not album_dir.exists()
+    assert artist_dir.exists()
+    assert other_album_dir.exists()
+
+
+def test_prune_never_removes_root_even_if_empty(tmp_path):
+    root = tmp_path
+
+    main._prune_empty_parent_dirs(root, root)
+
+    assert root.exists()
+
+
+def test_prune_leaves_folder_with_a_leftover_file(tmp_path):
+    # e.g. a playlist's .m3u is still there even though its last track
+    # was just deleted — the folder isn't actually empty.
+    root = tmp_path
+    playlist_dir = root / 'My Playlist'
+    playlist_dir.mkdir()
+    (playlist_dir / 'My Playlist.m3u').write_text(
+        '#EXTM3U\n', encoding='utf-8'
+    )
+
+    main._prune_empty_parent_dirs(playlist_dir, root)
+
+    assert playlist_dir.exists()
+
+
+def test_prune_no_op_when_folder_already_gone(tmp_path):
+    root = tmp_path
+    already_gone = root / 'Nonexistent'
+
+    # Must not raise — nothing to prune, the caller's own folder may
+    # already not exist in edge cases.
+    main._prune_empty_parent_dirs(already_gone, root)
+
+
+def test_prune_refuses_to_climb_outside_root(tmp_path):
+    root = tmp_path / 'downloads'
+    root.mkdir()
+    outside = tmp_path / 'outside'
+    outside.mkdir()
+
+    main._prune_empty_parent_dirs(outside, root)
+
+    # `outside` isn't under `root` at all — must be left untouched.
+    assert outside.exists()


### PR DESCRIPTION
Deleting a track from the Library page only removed the audio file, leaving things behind:

1. the `.lrc` synced-lyrics sidecar (`downtify/downloader.py:embed_lyrics` writes one sharing the audio file's basename);
2. under *Organize by album*, the album's shared `cover.jpg` (`Downloader._save_album_cover`) — one file per album folder, used by every track in it;
3. the (now possibly empty) per-playlist/artist/album folder itself, and any of its now-empty ancestor folders, all the way up to the downloads directory root.

- `main.py`: `_delete_lrc_sidecar()`, `_delete_album_cover_if_orphaned()` and the new `_prune_empty_parent_dirs()`, called in that order from `DELETE /delete` right after the audio file is removed. `_prune_empty_parent_dirs` climbs one directory at a time starting at the deleted file's folder, removing each one while it's genuinely empty (`iterdir()` finds nothing), and stops at the first non-empty ancestor or at the downloads directory root — the root itself is never removed even if it ends up empty. All three cleanups are best-effort: a missing file/folder or an `OSError` never fails the deletion that already succeeded.
- The cover check looks at the audio file's own folder (checked *after* it's already gone) for any remaining file with an audio extension; deduplicated that extension set (`.mp3`, `.m4a`, `.flac`, `.ogg`, `.wav`, `.aac`, `.opus`), previously inlined separately in `/list` and `/tracks`, into one `_AUDIO_EXTENSIONS` module constant shared by all three call sites.
- `tests/test_delete_sidecars.py` (17 tests): the lrc sidecar, the orphaned-cover check, and 7 new cases for the directory pruning — single empty folder, nested Artist/Album climbing up to root, stops at the first ancestor that still holds another album, never removes the root even if empty, leaves a folder alone when a leftover file (e.g. `.m3u`) remains, no-ops when the folder is already gone, and refuses to climb outside the given root. Module-level functions tested directly — `DELETE /delete` lives inside `main.build_app()` alongside the other file-management routes, none of which have route-level tests in this suite (no TestClient fixture).

fix #319